### PR TITLE
fix: unwrap getNormalizedURL return value; extend stripInboundMeta for gateway injections

### DIFF
--- a/src/__tests__/utils/chat-utils.test.ts
+++ b/src/__tests__/utils/chat-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripInboundMeta, textFromMessage } from '@/screens/chat/utils'
+import type { GatewayMessage } from '@/screens/chat/types'
+
+describe('chat utils', () => {
+  describe('stripInboundMeta', () => {
+    it('removes conversation metadata and timestamp prefix', () => {
+      const input = [
+        'Conversation info (untrusted metadata):',
+        '```json',
+        '{"channel":"telegram"}',
+        '```',
+        '[Tue 2026-03-10 12:05 GMT+4] hello there',
+      ].join('\n')
+
+      expect(stripInboundMeta(input)).toBe('hello there')
+    })
+
+    it('removes injected supermemory, workspace rules, and sender metadata blocks', () => {
+      const input = [
+        '<supermemory-context>secret context</supermemory-context>',
+        'Sender (untrusted metadata):',
+        '```text',
+        '{"sessionKey":"agent:main:main"}',
+        '```',
+        '<supermemory-containers>container dump</supermemory-containers>',
+        '<workspace-critical-rules>never show this</workspace-critical-rules>',
+        '[Tue 2026-03-10 12:05 GMT+4] actual user message',
+      ].join('\n')
+
+      expect(stripInboundMeta(input)).toBe('actual user message')
+    })
+
+    it('keeps normal message content intact', () => {
+      expect(stripInboundMeta('Meet me at [Tue 2026-03-10 12:05 GMT+4] maybe?')).toBe(
+        'Meet me at [Tue 2026-03-10 12:05 GMT+4] maybe?',
+      )
+    })
+  })
+
+  describe('textFromMessage', () => {
+    it('returns cleaned text content from a gateway message', () => {
+      const message: GatewayMessage = {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: '<supermemory-context>hidden</supermemory-context>\nreal text',
+          },
+        ],
+      }
+
+      expect(textFromMessage(message)).toBe('real text')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1 and #3, reported by @maciejlis.

## Changes

### Fix #1 — getNormalizedURL crash
`getNormalizedURL` from `@tanstack/router-core/ssr/server` now returns `{ url: URL, handledProtocolRelativeURL: boolean }` instead of a `URL` directly. Added unwrap to prevent crash on fresh npm installs.

### Fix #3 — Extend stripInboundMeta for gateway injections
`stripInboundMeta()` now also strips the following OpenClaw gateway injection patterns that were leaking into the chat UI:
- `<supermemory-context>...</supermemory-context>`
- `<supermemory-containers>...</supermemory-containers>`
- `<workspace-critical-rules>...</workspace-critical-rules>`
- `Sender (untrusted metadata):` fenced code blocks

Thanks @maciejlis for the detailed reports and suggested patches!