### PR TITLE
fix: topbar layout — padding, scroll, and context meter hover

### DIFF
--- a/src/screens/chat/components/chat-header.tsx
+++ b/src/screens/chat/components/chat-header.tsx
@@ -25,7 +25,7 @@ function ChatHeaderComponent({
     <div
       ref={wrapperRef}
       data-tauri-drag-region
-      className="border-b border-primary-200 px-4 h-12 flex min-w-0 items-center overflow-x-hidden bg-surface tauri-drag-header"
+      className="border-b border-primary-200 pr-4 h-12 flex shrink-0 min-w-0 items-center bg-surface tauri-drag-header"
     >
       {showSidebarButton ? (
         <Button

--- a/src/styles.css
+++ b/src/styles.css
@@ -510,20 +510,19 @@ code {
 
 /* Tauri desktop: offset for macOS traffic light buttons */
 .tauri-drag-header {
-  padding-left: env(titlebar-area-x, 1rem);
+  padding-left: 2rem;
+}
+
+html.tauri .tauri-drag-header {
+  padding-left: 5rem;
 }
 
 @supports (padding-left: env(titlebar-area-x)) {
-  .tauri-drag-header {
+  html.tauri .tauri-drag-header {
     padding-left: calc(
       env(titlebar-area-x) + env(titlebar-area-width) + 0.5rem
     );
   }
-}
-
-/* Fallback: detect Tauri via window.__TAURI__ injected by runtime */
-html.tauri .tauri-drag-header {
-  padding-left: 5rem;
 }
 
 ::selection {


### PR DESCRIPTION
## Summary
- Fix header left padding being reset to 0 in regular browsers due to CSS `@supports` block overriding base rule with invalid `env()` values at computed-value time
- Remove `overflow-x-hidden` from header that was clipping the context meter hover tooltip
- Add `shrink-0` to prevent header from being compressed

## Motivation
The `@supports (padding-left: env(titlebar-area-x))` block passes in all modern browsers (they support `env()` syntax), but the undefined Tauri-specific env vars cause the property to become invalid at computed-value time, resetting `padding-left` to 0. This made the session title appear flush against the sidebar border. The `overflow-x-hidden` on the same header element was also clipping the context meter's absolutely-positioned hover tooltip.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Tested locally in dev mode (`npm run dev`)
- [x] Tested production build (`npm run build`)

## Checklist
- [x] My code follows the project's code style (function declarations, Tailwind CSS)
- [x] My branch name follows the convention (`fix/`)
- [x] No new dependencies added

## Related Issues
N/A

## Upstream Consideration
- [x] Yes, this is a generic feature suitable for WebClaw upstream

## Additional Notes
The fix scopes the `@supports` block to `html.tauri` only, so it only applies in Tauri desktop contexts where the env vars are actually defined. Regular browsers get a clean `padding-left: 2rem` base rule.