### PR TITLE
fix: dark mode visibility for slash commands, command help modal, and context meter

### DIFF
--- a/src/components/command-help.tsx
+++ b/src/components/command-help.tsx
@@ -95,7 +95,7 @@ export function CommandHelp({ className, onCommandSelect }: CommandHelpProps) {
                   onClick={() => handleCommandClick(cmd.command)}
                   className="w-full flex items-start gap-3 px-3 py-2 rounded-lg hover:bg-primary-100 dark:hover:bg-neutral-800 transition-colors text-left"
                 >
-                  <code className="text-sm font-mono font-medium text-primary-700 dark:text-primary-300 bg-primary-100 dark:bg-neutral-800 px-1.5 py-0.5 rounded min-w-[80px]">
+                  <code className="text-sm font-mono font-medium text-primary-700 dark:text-primary-700 bg-primary-100 dark:bg-neutral-800 px-1.5 py-0.5 rounded min-w-[80px]">
                     {cmd.command}
                   </code>
                   <div className="flex-1 min-w-0">

--- a/src/screens/chat/components/context-meter.tsx
+++ b/src/screens/chat/components/context-meter.tsx
@@ -155,18 +155,18 @@ function ContextMeterComponent({
           )}
         >
           <div className="flex items-center gap-2 mb-1.5">
-            <span className="text-primary-500 dark:text-primary-400">
+            <span className="text-primary-500 dark:text-primary-500">
               Context window
             </span>
             <span className={cn('font-semibold', colors.text)}>
               {percentage}%
             </span>
           </div>
-          <div className="flex items-center gap-1.5 text-primary-700 dark:text-primary-300">
+          <div className="flex items-center gap-1.5 text-primary-700 dark:text-primary-700">
             <span className="font-medium">{usedStr}</span>
-            <span className="text-primary-400">/</span>
+            <span className="text-primary-400 dark:text-primary-500">/</span>
             <span>{maxStr}</span>
-            <span className="text-primary-400">tokens</span>
+            <span className="text-primary-400 dark:text-primary-500">tokens</span>
           </div>
           {/* Wider bar in tooltip */}
           <div className="w-full h-1.5 rounded-full bg-primary-200 dark:bg-primary-700 overflow-hidden mt-1.5">

--- a/src/screens/chat/components/slash-command-menu.tsx
+++ b/src/screens/chat/components/slash-command-menu.tsx
@@ -49,8 +49,8 @@ function SlashCommandMenuComponent({
               )}
             >
               <div className="flex items-start gap-3">
-                <code className="min-w-[90px] font-mono text-xs text-primary-300">{item.command}</code>
-                <span className="text-xs text-neutral-300">{item.description}</span>
+                <code className="min-w-[90px] font-mono text-xs text-primary-700 dark:text-primary-700">{item.command}</code>
+                <span className="text-xs text-primary-600 dark:text-primary-600">{item.description}</span>
               </div>
             </button>
           )


### PR DESCRIPTION
## Problem
In dark mode, several UI elements use `primary-300` for text color. Due to the inverted lightness scale in the dark theme (`primary-300` = oklch lightness 0.3), text appears nearly black on dark backgrounds — effectively invisible.

## Affected components
1. **Slash command menu** (`slash-command-menu.tsx`) — command names and descriptions unreadable when typing `/` in chat input
2. **Command help modal** (`command-help.tsx`) — command code tags in boxes too dark
3. **Context meter hover** (`context-meter.tsx`) — token count and divider text invisible on hover popup

## Fix
Replaced `dark:text-primary-300` (lightness 0.3) with `dark:text-primary-700` (lightness 0.73) across all three components. Also updated divider/secondary text from `dark:text-primary-400` to `dark:text-primary-500` for consistent contrast.

## Screenshots
Dark mode before: text nearly invisible on dark backgrounds
Dark mode after: readable contrast with proper lightness values