### PR TITLE
fix: streaming with tool-call support (#4)

### DIFF
--- a/src/routes/api/send.ts
+++ b/src/routes/api/send.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { gatewayRpc } from '../../server/gateway'
+import { gatewayRpc, gatewayRpcShared } from '../../server/gateway'
 
 type SessionsResolveResponse = {
   ok?: boolean
@@ -71,7 +71,7 @@ export const Route = createFileRoute('/api/send')({
             sessionKey = 'main'
           }
 
-          const res = await gatewayRpc<{ runId: string }>('chat.send', {
+          const res = await gatewayRpcShared<{ runId: string }>('chat.send', {
             sessionKey,
             message,
             thinking,
@@ -83,7 +83,7 @@ export const Route = createFileRoute('/api/send')({
               typeof body.idempotencyKey === 'string'
                 ? body.idempotencyKey
                 : randomUUID(),
-          })
+          }, sessionKey)
 
           return json({ ok: true, ...res, sessionKey })
         } catch (err) {

--- a/src/routes/api/stream.ts
+++ b/src/routes/api/stream.ts
@@ -1,135 +1,111 @@
-import { PassThrough } from 'node:stream'
-import { Readable } from 'node:stream'
+import { PassThrough, Readable } from 'node:stream'
 import { createFileRoute } from '@tanstack/react-router'
-import {
-  subscribeGatewayEvents,
-  type GatewayEvent,
-} from '../../server/gateway'
+import { acquireGatewayClient } from '../../server/gateway'
+
+type StreamEventPayload = {
+  event: string
+  payload?: unknown
+  seq?: number
+  stateVersion?: number
+}
 
 export const Route = createFileRoute('/api/stream')({
   server: {
     handlers: {
       GET: async ({ request }) => {
         const url = new URL(request.url)
-        const sessionKey = url.searchParams.get('sessionKey')
+        const sessionKey = url.searchParams.get('sessionKey')?.trim() || ''
+        const friendlyId = url.searchParams.get('friendlyId')?.trim() || ''
+        const key = sessionKey || friendlyId
 
-        if (!sessionKey) {
+        if (!key) {
           return new Response(
-            JSON.stringify({ ok: false, error: 'sessionKey required' }),
+            JSON.stringify({ ok: false, error: 'sessionKey or friendlyId required' }),
             { status: 400, headers: { 'content-type': 'application/json' } },
           )
         }
 
-        // Use Node.js PassThrough stream — Web ReadableStream gets buffered by
-        // Vite's dev server, causing the browser to only see data after the
-        // stream ends. PassThrough + Readable.toWeb() bypasses this buffering.
         const pass = new PassThrough()
         const encoder = new TextEncoder()
 
         let closed = false
-        let unsubscribe: (() => void) | null = null
+        let heartbeat: ReturnType<typeof setInterval> | null = null
+        let releaseClient: (() => void) | null = null
 
-        function sendSSE(event: string, data: unknown) {
+        function writeChunk(chunk: string) {
           if (closed) return
           try {
-            pass.write(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+            pass.write(encoder.encode(chunk))
           } catch {
-            // stream may have closed
+            cleanup()
           }
+        }
+
+        function send(data: StreamEventPayload) {
+          writeChunk(`data: ${JSON.stringify(data)}\n\n`)
         }
 
         function cleanup() {
           if (closed) return
           closed = true
-          if (unsubscribe) {
-            unsubscribe()
-            unsubscribe = null
+          if (heartbeat) {
+            clearInterval(heartbeat)
+            heartbeat = null
           }
-          try { pass.end() } catch {}
+          if (releaseClient) {
+            releaseClient()
+            releaseClient = null
+          }
+          try {
+            pass.end()
+          } catch {
+            // ignore
+          }
         }
 
-        // Send initial ping to establish connection
-        pass.write(encoder.encode(': connected\n\n'))
+        writeChunk(': connected\n\n')
+        heartbeat = setInterval(() => {
+          writeChunk('event: ping\ndata: {}\n\n')
+        }, 15000)
 
-        // Track whether we've received agent-stream events.
-        // If we get agent events, prefer those for deltas (they're raw
-        // token deltas). chat.delta events contain accumulated buffered
-        // text which can overlap / duplicate the agent stream.
-        let gotAgentStream = false
+        try {
+          const handle = await acquireGatewayClient(key, {
+            onEvent(event) {
+              // Filter events to only forward those relevant to this session.
+              // The gateway broadcasts ALL events to every connected client.
+              const p = event.payload as Record<string, unknown> | undefined
+              const eventSessionKey = typeof p?.sessionKey === 'string' ? p.sessionKey : ''
 
-        unsubscribe = subscribeGatewayEvents(sessionKey, (evt: GatewayEvent) => {
-          if (evt.event === 'agent') {
-            const payload = evt.payload as Record<string, unknown>
-            const agentStream = payload.stream as string | undefined
-
-            if (agentStream === 'assistant') {
-              gotAgentStream = true
-              const data = (payload.data ?? payload) as Record<string, unknown>
-              const text =
-                typeof data.delta === 'string'
-                  ? data.delta
-                  : typeof data.text === 'string'
-                    ? data.text
-                    : typeof payload.text === 'string'
-                      ? payload.text
-                      : typeof payload.delta === 'string'
-                        ? payload.delta
-                        : ''
-              if (text) {
-                sendSSE('delta', { text, sessionKey })
+              // Allow events without a sessionKey (health, presence, tick, etc.)
+              // Allow events matching this session's key (exact or agent: prefixed)
+              if (eventSessionKey && !eventSessionKey.includes(key)) {
+                return
               }
-            } else if (agentStream === 'tool') {
-              gotAgentStream = true
-              const tdata = (payload.data ?? payload) as Record<string, unknown>
-              sendSSE('tool', {
-                name: tdata.name ?? tdata.toolName ?? payload.name ?? '',
-                status: tdata.phase ?? tdata.status ?? payload.phase ?? 'running',
-                id: tdata.id ?? tdata.toolCallId ?? payload.id ?? '',
-                sessionKey,
+
+              send({
+                event: event.event,
+                payload: event.payload,
+                seq: event.seq,
+                stateVersion: event.stateVersion,
               })
-            } else if (agentStream === 'lifecycle') {
-              const ldata = (payload.data ?? payload) as Record<string, unknown>
-              const phase = (ldata.phase ?? payload.phase) as string | undefined
-              if (phase === 'end' || phase === 'error') {
-                sendSSE('done', {
-                  sessionKey,
-                  status: phase,
-                  error: phase === 'error' ? payload.error : undefined,
-                })
-                cleanup()
-              }
-            }
-          } else if (evt.event === 'chat') {
-            const payload = evt.payload as Record<string, unknown>
-            // Gateway sends `state` (not `kind`) — "delta" or "final"
-            const state = (payload.state ?? payload.kind) as string | undefined
-            const msg = payload.message as Record<string, unknown> | undefined
+            },
+            onError(error) {
+              send({ event: 'error', payload: error.message })
+            },
+          })
 
-            if (state === 'delta' && !gotAgentStream) {
-              const content = Array.isArray(msg?.content)
-                ? (msg.content as Record<string, unknown>[])
-                : []
-              const firstBlock = content[0]
-              const text: string =
-                typeof firstBlock?.text === 'string'
-                  ? firstBlock.text
-                  : typeof payload.text === 'string'
-                    ? payload.text
-                    : typeof payload.delta === 'string'
-                      ? payload.delta
-                      : ''
-              if (text) {
-                sendSSE('delta', { text, sessionKey })
-              }
-            } else if (state === 'final') {
-              sendSSE('done', { sessionKey, status: 'end' })
-              cleanup()
-            }
+          if (closed) {
+            handle.release()
+          } else {
+            releaseClient = handle.release
           }
-        })
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error)
+          send({ event: 'error', payload: message })
+          cleanup()
+        }
 
-        // Handle client disconnect
-        request.signal?.addEventListener('abort', cleanup)
+        request.signal.addEventListener('abort', cleanup, { once: true })
 
         const webStream = Readable.toWeb(pass) as ReadableStream<Uint8Array>
 

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -699,6 +699,12 @@ export function ChatScreen({
     streamingNotificationTextRef.current = ''
     streamStart()
 
+    // Start SSE stream BEFORE sending so we don't miss early events
+    const preStreamKey = sessionKey || friendlyId
+    if (preStreamKey) {
+      startStream(preStreamKey)
+    }
+
     fetch('/api/send', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/src/screens/chat/hooks/use-streaming.ts
+++ b/src/screens/chat/hooks/use-streaming.ts
@@ -1,14 +1,30 @@
-import { useCallback, useRef, useState } from 'react'
+import {
+  useCallback,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
 
 export type StreamingState = {
-  /** Whether we're currently receiving streamed content */
   active: boolean
-  /** Accumulated text from assistant deltas */
   text: string
-  /** Currently active tool calls */
   tools: Array<{ name: string; status: string; id: string }>
-  /** The sessionKey this stream is for */
   sessionKey: string | null
+}
+
+type RawGatewayEvent = {
+  event?: string
+  payload?: unknown
+  seq?: number
+  stateVersion?: number
+}
+
+type RawAgentPayload = {
+  runId?: unknown
+  sessionKey?: unknown
+  stream?: unknown
+  data?: unknown
 }
 
 const INITIAL_STATE: StreamingState = {
@@ -18,10 +34,6 @@ const INITIAL_STATE: StreamingState = {
   sessionKey: null,
 }
 
-/**
- * Hook that manages an SSE connection to /api/stream for real-time
- * message streaming from the Gateway's persistent WebSocket.
- */
 export function useStreaming(options: {
   onDone: (sessionKey: string) => void
   onError?: (error: string) => void
@@ -29,10 +41,9 @@ export function useStreaming(options: {
 }) {
   const [state, setState] = useState<StreamingState>(INITIAL_STATE)
   const eventSourceRef = useRef<EventSource | null>(null)
-  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const streamStartRef = useRef<number | null>(null)
   const doneRef = useRef(false)
+  const finalStateRef = useRef(false)
+  const activeRunsRef = useRef(new Set<string>())
   const onDoneRef = useRef(options.onDone)
   const onErrorRef = useRef(options.onError)
   const onAssistantDeltaRef = useRef(options.onAssistantDelta)
@@ -40,50 +51,10 @@ export function useStreaming(options: {
   onErrorRef.current = options.onError
   onAssistantDeltaRef.current = options.onAssistantDelta
 
-  function clearPolling() {
-    if (pollingTimeoutRef.current) {
-      window.clearTimeout(pollingTimeoutRef.current)
-      pollingTimeoutRef.current = null
-    }
-    if (pollingRef.current) {
-      window.clearInterval(pollingRef.current)
-      pollingRef.current = null
-    }
-  }
-
-  function startPolling(sessionKey: string, startedAt: number) {
-    if (pollingRef.current) return
-    pollingRef.current = window.setInterval(async () => {
-      try {
-        const res = await fetch(
-          `/api/history?sessionKey=${encodeURIComponent(sessionKey)}`,
-        )
-        if (!res.ok) return
-        const data = (await res.json()) as {
-          messages?: Array<{ role?: string; timestamp?: number }>
-        }
-        const messages = Array.isArray(data.messages) ? data.messages : []
-        // Allow 10s clock-skew tolerance between server and browser
-        const hasNewAssistant = messages.some((message) => {
-          if (!message || message.role !== 'assistant') return false
-          if (typeof message.timestamp !== 'number') return false
-          return message.timestamp > startedAt - 3_000
-        })
-        if (!hasNewAssistant) return
-        if (eventSourceRef.current) {
-          eventSourceRef.current.close()
-          eventSourceRef.current = null
-        }
-        clearPolling()
-        setState((prev) => ({ ...prev, active: false }))
-        onDoneRef.current(sessionKey)
-      } catch {}
-    }, 2000)
-  }
-
   const stop = useCallback((options?: { preserveState?: boolean }) => {
     doneRef.current = true
-    clearPolling()
+    finalStateRef.current = false
+    activeRunsRef.current.clear()
     if (eventSourceRef.current) {
       eventSourceRef.current.close()
       eventSourceRef.current = null
@@ -95,92 +66,176 @@ export function useStreaming(options: {
     setState(INITIAL_STATE)
   }, [])
 
-  const start = useCallback(
-    function start(sessionKey: string) {
-      doneRef.current = false
-      clearPolling()
-      streamStartRef.current = Date.now()
-      // Close any existing connection
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close()
-        eventSourceRef.current = null
-      }
+  const start = useCallback(function start(sessionKey: string) {
+    doneRef.current = false
+    finalStateRef.current = false
+    activeRunsRef.current.clear()
 
-      setState({
-        active: true,
-        text: '',
-        tools: [],
-        sessionKey,
-      })
+    setState({
+      active: true,
+      text: '',
+      tools: [],
+      sessionKey,
+    })
 
-      const es = new EventSource(`/api/stream?sessionKey=${encodeURIComponent(sessionKey)}`)
-      eventSourceRef.current = es
+    // If we already have an open EventSource for this session, reuse it.
+    // The server stream stays open across multiple messages.
+    if (eventSourceRef.current) {
+      return
+    }
 
-      es.addEventListener('delta', (e) => {
-        try {
-          const data = JSON.parse(e.data) as { text: string; sessionKey: string }
-          setState((prev) => ({
-            ...prev,
-            text: prev.text + data.text,
-          }))
-          onAssistantDeltaRef.current?.({ text: data.text, sessionKey: data.sessionKey })
-        } catch {}
-      })
+    const es = new EventSource(`/api/stream?sessionKey=${encodeURIComponent(sessionKey)}`)
+    eventSourceRef.current = es
 
-      es.addEventListener('tool', (e) => {
-        try {
-          const data = JSON.parse(e.data) as {
-            name: string
-            status: string
-            id: string
-            sessionKey: string
-          }
-          setState((prev) => {
-            const existingIdx = prev.tools.findIndex((t) => t.id === data.id)
-            const tools = [...prev.tools]
-            if (existingIdx >= 0) {
-              tools[existingIdx] = { name: data.name, status: data.status, id: data.id }
-            } else {
-              tools.push({ name: data.name, status: data.status, id: data.id })
-            }
-            return { ...prev, tools }
+    es.addEventListener('message', (e) => {
+      try {
+        const data = JSON.parse(e.data) as RawGatewayEvent
+        if (data.event === 'agent') {
+          handleAgentEvent(data.payload, sessionKey, {
+            setState,
+            onAssistantDelta: onAssistantDeltaRef.current,
+            activeRuns: activeRunsRef.current,
           })
-        } catch {}
-      })
-
-      es.addEventListener('done', (e) => {
-        try {
-          const data = JSON.parse(e.data) as { sessionKey: string; status: string }
-          doneRef.current = true
-          clearPolling()
-          es.close()
-          eventSourceRef.current = null
-          // Mark stream as inactive but keep text/tools so the UI can
-          // continue displaying them until history refetch completes.
-          setState((prev) => ({ ...prev, active: false }))
-          onDoneRef.current(data.sessionKey)
-        } catch {}
-      })
-
-      es.onerror = () => {
-        // EventSource auto-reconnects on error, but if the connection is
-        // definitely broken we fall back to polling. Close after a brief
-        // moment so we don't spin-reconnect.
-        if (es.readyState === EventSource.CLOSED) {
-          es.close()
-          eventSourceRef.current = null
-          setState(INITIAL_STATE)
-          onErrorRef.current?.('Stream connection lost')
+          return
         }
+
+        if (data.event === 'chat') {
+          const chatPayload = asRecord(data.payload)
+          const eventSessionKey =
+            normalizeString(chatPayload?.sessionKey) || sessionKey
+          const chatState = normalizeString(chatPayload?.state)
+
+          if (chatState === 'final') {
+            finalStateRef.current = true
+          }
+
+          if (
+            !doneRef.current &&
+            finalStateRef.current &&
+            (chatState === 'final' || activeRunsRef.current.size === 0)
+          ) {
+            doneRef.current = true
+            // Don't close the EventSource — keep it alive for subsequent
+            // messages in the same chat. The server stream stays open and
+            // will forward events for the next chat.send call too.
+            setState((prev) => ({ ...prev, active: false }))
+            onDoneRef.current(eventSessionKey)
+          }
+          return
+        }
+
+        if (data.event === 'error') {
+          const message =
+            typeof data.payload === 'string'
+              ? data.payload
+              : 'Stream connection lost'
+          onErrorRef.current?.(message)
+        }
+      } catch {
+        // ignore parse errors
       }
-      pollingTimeoutRef.current = window.setTimeout(() => {
-        if (doneRef.current) return
-        const startedAt = streamStartRef.current ?? Date.now()
-        startPolling(sessionKey, startedAt)
-      }, 3000)
-    },
-    [],
-  )
+    })
+
+    es.onerror = () => {
+      if (doneRef.current) return
+      if (es.readyState === EventSource.CLOSED) {
+        eventSourceRef.current = null
+        setState((prev) => ({ ...prev, active: false }))
+        onErrorRef.current?.('Stream connection lost')
+      }
+    }
+  }, [])
 
   return { streaming: state, startStream: start, stopStream: stop }
+}
+
+function handleAgentEvent(
+  payload: unknown,
+  fallbackSessionKey: string,
+  options: {
+    setState: Dispatch<SetStateAction<StreamingState>>
+    onAssistantDelta?: (payload: { text: string; sessionKey: string }) => void
+    activeRuns: Set<string>
+  },
+) {
+  const agentPayload = asRecord(payload) as RawAgentPayload | null
+  const stream = normalizeString(agentPayload?.stream)
+  const runId = normalizeString(agentPayload?.runId)
+  const sessionKey = normalizeString(agentPayload?.sessionKey) || fallbackSessionKey
+  const streamData = asRecord(agentPayload?.data)
+
+  if (runId) {
+    if (stream === 'lifecycle') {
+      const phase = normalizeString(streamData?.phase)
+      if (phase === 'end' || phase === 'error' || phase === 'abort') {
+        options.activeRuns.delete(runId)
+      } else if (phase) {
+        options.activeRuns.add(runId)
+      }
+    } else {
+      options.activeRuns.add(runId)
+    }
+  }
+
+  if (stream === 'assistant') {
+    const text = normalizeString(streamData?.delta) || normalizeString(streamData?.text)
+    if (!text) return
+    options.setState((prev) => ({
+      ...prev,
+      sessionKey,
+      text: prev.text + text,
+    }))
+    options.onAssistantDelta?.({ text, sessionKey })
+    return
+  }
+
+  if (!stream.includes('tool')) return
+
+  const toolId =
+    normalizeString(streamData?.toolCallId) ||
+    normalizeString(streamData?.id) ||
+    normalizeString(streamData?.callId) ||
+    `${runId || 'tool'}:${normalizeString(streamData?.toolName) || normalizeString(streamData?.name) || 'unknown'}`
+  const toolName =
+    normalizeString(streamData?.toolName) ||
+    normalizeString(streamData?.name) ||
+    'Tool'
+  const toolStatus = deriveToolStatus(stream, streamData)
+
+  options.setState((prev) => {
+    const tools = [...prev.tools]
+    const index = tools.findIndex((tool) => tool.id === toolId)
+    const nextTool = { id: toolId, name: toolName, status: toolStatus }
+    if (index >= 0) {
+      tools[index] = nextTool
+    } else {
+      tools.push(nextTool)
+    }
+    return {
+      ...prev,
+      sessionKey,
+      tools,
+    }
+  })
+}
+
+function deriveToolStatus(stream: string, data: Record<string, unknown> | null): string {
+  const explicitStatus =
+    normalizeString(data?.phase) ||
+    normalizeString(data?.status) ||
+    normalizeString(data?.state)
+  if (explicitStatus) return explicitStatus
+  if (stream.includes('result') || stream.includes('output')) return 'done'
+  if (stream.includes('call')) return 'running'
+  return 'running'
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
 }

--- a/src/server/gateway.ts
+++ b/src/server/gateway.ts
@@ -51,6 +51,29 @@ export type GatewayEvent = {
 
 export type StreamListener = (event: GatewayEvent) => void
 
+type GatewayClientCallbacks = {
+  onEvent?: StreamListener
+  onError?: (error: Error) => void
+}
+
+type GatewayClient = {
+  connect: () => Promise<void>
+  sendReq: <TPayload = unknown>(method: string, params?: unknown) => Promise<TPayload>
+  close: () => void
+  isClosed: () => boolean
+  addCallbacks: (callbacks?: GatewayClientCallbacks) => () => void
+}
+
+type GatewayClientEntry = {
+  refs: number
+  client: GatewayClient
+}
+
+type GatewayClientHandle = {
+  client: GatewayClient
+  release: () => void
+}
+
 // ─── Config helpers ─────────────────────────────────────────────────────
 
 function getGatewayConfig() {
@@ -686,6 +709,268 @@ function getPersistentConnection(): PersistentGatewayConnection {
     _proc.__opencamiGatewayInstance = new PersistentGatewayConnection()
   }
   return _proc.__opencamiGatewayInstance
+}
+
+
+const sharedGatewayClients = new Map<string, GatewayClientEntry>()
+
+function createGatewayClient(): GatewayClient {
+  const pendingRpcs = new Map<string, PendingRpc>()
+  const callbacks = new Set<GatewayClientCallbacks>()
+  let ws: WebSocket | null = null
+  let closed = false
+  let connected = false
+  let connectPromise: Promise<void> | null = null
+
+  function rejectAll(err: Error) {
+    for (const [, pending] of pendingRpcs) {
+      clearTimeout(pending.timer)
+      pending.reject(err)
+    }
+    pendingRpcs.clear()
+  }
+
+  function waitForRes(id: string, timeoutMs = 30_000): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingRpcs.delete(id)
+        reject(new Error(`RPC timeout waiting for ${id}`))
+      }, timeoutMs)
+      pendingRpcs.set(id, { resolve, reject, timer })
+    })
+  }
+
+  function emitError(error: Error) {
+    for (const callback of callbacks) {
+      try {
+        callback.onError?.(error)
+      } catch {}
+    }
+  }
+
+  function emitEvent(event: GatewayEvent) {
+    for (const callback of callbacks) {
+      try {
+        callback.onEvent?.(event)
+      } catch {}
+    }
+  }
+
+  function handleMessage(data: WebSocket.Data) {
+    try {
+      const str = typeof data === 'string' ? data : data.toString()
+      const parsed = JSON.parse(str) as GatewayFrame
+
+      if (parsed.type === 'res') {
+        const pending = pendingRpcs.get(parsed.id)
+        if (!pending) return
+        pendingRpcs.delete(parsed.id)
+        clearTimeout(pending.timer)
+        if (parsed.ok) pending.resolve(parsed.payload)
+        else pending.reject(new GatewayResponseError(parsed.error?.message ?? 'gateway error', parsed.error?.code))
+        return
+      }
+
+      if (parsed.type === 'event') {
+        emitEvent({
+          event: parsed.event,
+          payload: (parsed.payload ?? {}) as Record<string, unknown>,
+          seq: parsed.seq,
+        })
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  function handleClose() {
+    const wasConnected = connected
+    connected = false
+    ws = null
+    rejectAll(new Error('Connection closed'))
+    if (!closed && wasConnected) {
+      emitError(new Error('Gateway client connection closed'))
+    }
+  }
+
+  async function connect(): Promise<void> {
+    if (closed) throw new Error('Gateway client closed')
+    if (connected && ws?.readyState === WebSocket.OPEN) return
+    if (connectPromise) return connectPromise
+
+    connectPromise = (async () => {
+      const { url, token, password } = getGatewayConfig()
+      const origin = process.env.OPENCAMI_ORIGIN?.trim()
+      const nextWs = origin
+        ? new WebSocket(url, { headers: { Origin: origin } })
+        : new WebSocket(url)
+
+      ws = nextWs
+
+      await new Promise<void>((resolve, reject) => {
+        const onOpen = () => { cleanup(); resolve() }
+        const onError = (err: Error) => { cleanup(); reject(new Error(`WS open error: ${err.message}`)) }
+        const cleanup = () => { nextWs.off('open', onOpen); nextWs.off('error', onError) }
+        nextWs.on('open', onOpen)
+        nextWs.on('error', onError)
+      })
+
+      const nonce = await new Promise<string>((resolve) => {
+        let done = false
+        const timer = setTimeout(() => {
+          if (done) return
+          done = true
+          resolve('')
+        }, 3000)
+
+        const onMessage = (data: WebSocket.Data) => {
+          try {
+            const str = typeof data === 'string' ? data : data.toString()
+            const parsed = JSON.parse(str) as GatewayFrame
+            if (parsed.type === 'event' && parsed.event === 'connect.challenge') {
+              const n = (parsed.payload as any)?.nonce
+              if (typeof n === 'string' && n.length > 0) {
+                clearTimeout(timer)
+                nextWs.off('message', onMessage)
+                if (done) return
+                done = true
+                resolve(n)
+              }
+            }
+          } catch {}
+        }
+
+        nextWs.on('message', onMessage)
+      })
+
+      nextWs.on('message', handleMessage)
+      nextWs.on('close', handleClose)
+      nextWs.on('error', (err: Error) => {
+        emitError(new Error(`Gateway client error: ${err.message}`))
+      })
+
+      const connectId = randomUUID()
+      const connectParams = buildConnectParams(url, token, password, nonce)
+      nextWs.send(JSON.stringify({
+        type: 'req',
+        id: connectId,
+        method: 'connect',
+        params: connectParams,
+      }))
+
+      const hello = await waitForRes(connectId, 10_000) as any
+      if (hello?.auth?.deviceToken) {
+        const identity = loadOrCreateDeviceIdentity()
+        storeDeviceToken(identity.deviceId, url, hello.auth.deviceToken)
+      }
+
+      connected = true
+    })()
+
+
+    try {
+      await connectPromise
+    } finally {
+      connectPromise = null
+    }
+  }
+
+  async function sendReq<TPayload = unknown>(method: string, params?: unknown): Promise<TPayload> {
+    await connect()
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error('Gateway client not connected')
+    }
+    const id = randomUUID()
+    ws.send(JSON.stringify({ type: 'req', id, method, params }))
+    return await waitForRes(id) as TPayload
+  }
+
+  function close() {
+    if (closed) return
+    closed = true
+    connected = false
+    rejectAll(new Error('Gateway client closed'))
+    const currentWs = ws
+    ws = null
+    if (currentWs) {
+      currentWs.off('message', handleMessage)
+      currentWs.off('close', handleClose)
+      currentWs.close()
+    }
+    callbacks.clear()
+  }
+
+  function isClosed() {
+    return closed
+  }
+
+  function addCallbacks(callbacksToAdd?: GatewayClientCallbacks) {
+    if (!callbacksToAdd?.onEvent && !callbacksToAdd?.onError) {
+      return () => {}
+    }
+    callbacks.add(callbacksToAdd)
+    return () => {
+      callbacks.delete(callbacksToAdd)
+    }
+  }
+
+  return { connect, sendReq, close, isClosed, addCallbacks }
+}
+
+function releaseGatewayClient(key: string) {
+  const entry = sharedGatewayClients.get(key)
+  if (!entry) return
+  entry.refs -= 1
+  if (entry.refs > 0) return
+  entry.client.close()
+  sharedGatewayClients.delete(key)
+}
+
+export async function acquireGatewayClient(
+  key: string,
+  callbacks?: GatewayClientCallbacks,
+): Promise<GatewayClientHandle> {
+  const existing = sharedGatewayClients.get(key)
+  if (existing && !existing.client.isClosed()) {
+    existing.refs += 1
+    const removeCallbacks = existing.client.addCallbacks(callbacks)
+    return {
+      client: existing.client,
+      release: () => {
+        removeCallbacks()
+        releaseGatewayClient(key)
+      },
+    }
+  }
+
+  const client = createGatewayClient()
+  const removeCallbacks = client.addCallbacks(callbacks)
+  await client.connect()
+  sharedGatewayClients.set(key, { refs: 1, client })
+  return {
+    client,
+    release: () => {
+      removeCallbacks()
+      releaseGatewayClient(key)
+    },
+  }
+}
+
+export async function gatewayRpcShared<TPayload = unknown>(
+  method: string,
+  params?: unknown,
+  key?: string,
+): Promise<TPayload> {
+  if (!key) {
+    return gatewayRpc<TPayload>(method, params)
+  }
+
+  const existing = sharedGatewayClients.get(key)
+  if (!existing || existing.client.isClosed()) {
+    return gatewayRpc<TPayload>(method, params)
+  }
+
+  return existing.client.sendReq<TPayload>(method, params)
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────

--- a/src/server/gateway.ts
+++ b/src/server/gateway.ts
@@ -263,7 +263,7 @@ function buildConnectParams(url: string, token: string, password: string, nonce:
       mode: clientMode,
       instanceId: loadOrCreateInstanceId(),
     },
-    caps: [],
+    caps: ['tool-events'],
     auth: {
       token: token || undefined,
       password: password || undefined,
@@ -463,7 +463,7 @@ class PersistentGatewayConnection {
           mode: 'webchat',
           instanceId: loadOrCreateInstanceId(),
         },
-        caps: [],
+        caps: ['tool-events'],
         auth: {
           token: token || undefined,
           password: password || undefined,


### PR DESCRIPTION
## What this fixes

Streaming was completely broken — responses only appeared after the full agent run completed, with no token-by-token output. Tool calls caused the stream to hang permanently.

### Root causes (3 issues, all fixed)

1. **Missing `tool-events` capability** — OpenCami connected to the gateway with `caps: []`, so the gateway never registered our connection for agent streaming events. Fixed: `caps: ["tool-events"]`

2. **Wrong connection for `chat.send`** — `chat.send` was sent via a throwaway WS connection (`gatewayRpc`) that closed immediately after. The gateway registered that dead connection's `connId` for events. Fixed: ported upstream's `acquireGatewayClient()` + `gatewayRpcShared()` so `chat.send` and event listening share the same persistent connection.

3. **Server-side stream filtering killed tool-call runs** — `stream.ts` parsed events server-side and sent `done` after the first `lifecycle.end`. But after a tool call, a new agent turn starts with new events. Fixed: replaced with a raw event proxy (matching upstream WebClaw) that forwards all gateway events to the client.

### Additional fixes in this PR
- SessionKey filter on the stream proxy to prevent cross-session event leakage
- EventSource reuse across messages (no close/reopen between sends)
- `startStream()` called before `fetch(/api/send)` to prevent race condition

### Known remaining issues (separate PRs)
- [ ] Tool call cards appear after text instead of before — rendering order bug
- [ ] Brief "Generating" flash before first delta arrives
- [ ] Session `main` streaming conflicts when Telegram is active (by design — shared session queue)
- [ ] `Sender (untrusted metadata)` blocks still visible in some sidebar previews

Fixes #4