### PR TITLE
fix: streaming reliability — dedup, gateway notice, tool cards

### DIFF
--- a/src/routes/api/stream.ts
+++ b/src/routes/api/stream.ts
@@ -71,14 +71,16 @@ export const Route = createFileRoute('/api/stream')({
         try {
           const handle = await acquireGatewayClient(key, {
             onEvent(event) {
-              // Filter events to only forward those relevant to this session.
-              // The gateway broadcasts ALL events to every connected client.
+              // Safety-net filter: the PersistentGatewayConnection already
+              // routes events by session key, but we double-check here to
+              // prevent any cross-session leakage in the SSE stream.
               const p = event.payload as Record<string, unknown> | undefined
               const eventSessionKey = typeof p?.sessionKey === 'string' ? p.sessionKey : ''
 
               // Allow events without a sessionKey (health, presence, tick, etc.)
-              // Allow events matching this session's key (exact or agent: prefixed)
-              if (eventSessionKey && !eventSessionKey.includes(key)) {
+              // Allow events matching this session's key (segment-based match
+              // on ':'-separated parts, e.g. 'agent:main:main' matches 'main').
+              if (eventSessionKey && eventSessionKey !== key && !eventSessionKey.split(':').includes(key)) {
                 return
               }
 

--- a/src/routes/api/stream.ts
+++ b/src/routes/api/stream.ts
@@ -35,6 +35,9 @@ export const Route = createFileRoute('/api/stream')({
         // Skip any event whose seq we've already forwarded. This prevents
         // doubled text from duplicate event dispatch in Vite SSR contexts.
         let lastSeq = -1
+        // Content-based dedup: skip consecutive events with identical payloads.
+        // Catches duplicates that carry different seq values.
+        let lastEventFingerprint = ''
 
         function writeChunk(chunk: string) {
           if (closed) return
@@ -80,6 +83,12 @@ export const Route = createFileRoute('/api/stream')({
                 if (event.seq <= lastSeq) return
                 lastSeq = event.seq
               }
+
+              // Content-based dedup: skip consecutive events with identical
+              // event type + payload. Catches duplicates with different seq.
+              const fp = event.event + ':' + JSON.stringify(event.payload)
+              if (fp === lastEventFingerprint) return
+              lastEventFingerprint = fp
 
               // Safety-net filter: the PersistentGatewayConnection already
               // routes events by session key, but we double-check here to

--- a/src/routes/api/stream.ts
+++ b/src/routes/api/stream.ts
@@ -31,6 +31,10 @@ export const Route = createFileRoute('/api/stream')({
         let closed = false
         let heartbeat: ReturnType<typeof setInterval> | null = null
         let releaseClient: (() => void) | null = null
+        // Seq-based dedup: gateway events carry incrementing seq numbers.
+        // Skip any event whose seq we've already forwarded. This prevents
+        // doubled text from duplicate event dispatch in Vite SSR contexts.
+        let lastSeq = -1
 
         function writeChunk(chunk: string) {
           if (closed) return
@@ -71,6 +75,12 @@ export const Route = createFileRoute('/api/stream')({
         try {
           const handle = await acquireGatewayClient(key, {
             onEvent(event) {
+              // Seq-based dedup: skip events already forwarded to this stream.
+              if (typeof event.seq === 'number') {
+                if (event.seq <= lastSeq) return
+                lastSeq = event.seq
+              }
+
               // Safety-net filter: the PersistentGatewayConnection already
               // routes events by session key, but we double-check here to
               // prevent any cross-session leakage in the SSE stream.

--- a/src/screens/chat/chat-queries.ts
+++ b/src/screens/chat/chat-queries.ts
@@ -40,7 +40,10 @@ export async function fetchHistory(payload: {
 
 export async function fetchGatewayStatus(): Promise<GatewayStatusResponse> {
   const controller = new AbortController()
-  const timeout = window.setTimeout(() => controller.abort(), 2500)
+  // The first ping can take a while because the server-side WS connection
+  // to the gateway must complete a full handshake (nonce exchange + connect
+  // RPC + optional device auth). 8s is generous enough for slow starts.
+  const timeout = window.setTimeout(() => controller.abort(), 8000)
 
   try {
     const res = await fetch('/api/ping', { signal: controller.signal })

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -333,6 +333,13 @@ export function ChatScreen({
       typeof lastAssistantIndex === 'number' &&
       (typeof lastUserIndex !== 'number' || lastAssistantIndex > lastUserIndex)
 
+    // Once streaming is done, prefer the persisted history over the streaming
+    // overlay. The streaming state may have accumulated garbled/doubled text
+    // from duplicate event delivery; history is always correct.
+    if (!streaming.active && assistantIsLatestTurn) {
+      return displayMessages
+    }
+
     if (assistantIsLatestTurn && typeof lastAssistantIndex === 'number') {
       const historyAssistant = displayMessages[lastAssistantIndex]
       const historyText = textFromMessage(historyAssistant)
@@ -353,7 +360,7 @@ export function ChatScreen({
 
     // No assistant response for the current turn in history yet — append streaming.
     return [...displayMessages, streamingMessage]
-  }, [displayMessages, streamingMessage, streaming.text, streaming.tools])
+  }, [displayMessages, streamingMessage, streaming.active, streaming.text, streaming.tools])
 
   const stableContentStyle = useMemo<React.CSSProperties>(() => ({}), [])
   refreshHistoryRef.current = function refreshHistory() {

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -268,35 +268,41 @@ export function ChatScreen({
     async (_sk: string) => {
       // 1. Refetch history so the final persisted message is available
       await historyQuery.refetch()
-      // 2. Close the SSE stream but keep the final streamed payload in state.
-      //    This prevents a one-frame gap if history paint lags behind refetch.
-      stopStream({ preserveState: true })
+      // 2. DON'T close the EventSource — keep it alive for subsequent
+      //    messages. The use-streaming hook already set active=false in the
+      //    onDone handler. Closing it here caused a race condition for the
+      //    second message: the shared gateway client was released, so
+      //    chat.send fell back to a different WS connection.
       streamFinish()
       void queryClient.invalidateQueries({ queryKey: chatQueryKeys.sessions })
     },
-    [historyQuery, queryClient, stopStream, streamFinish],
+    [historyQuery, queryClient, streamFinish],
   )
   handleStreamErrorRef.current = useCallback((_err: string) => {
     console.warn('[stream] SSE error, falling back to polling')
   }, [])
 
-  // Build a synthetic "streaming" assistant message from SSE deltas
+  // Build a synthetic "streaming" assistant message from SSE deltas.
+  // Uses contentBlocks to preserve the correct interleaving of text and
+  // tool-call events (e.g. text → tool → more text).
   const streamingMessage = useMemo<GatewayMessage | null>(() => {
-    // Keep showing streamed text until persisted history has visibly caught up.
-    // The merge step below removes this synthetic message once history's
-    // assistant text is at least as complete.
-    if (!streaming.text) return null
+    if (streaming.contentBlocks.length === 0) return null
+
     const content: GatewayMessage['content'] = []
-    // Add tool call indicators
-    for (const tool of streaming.tools) {
-      content.push({
-        type: 'toolCall' as const,
-        name: tool.name,
-        id: tool.id,
-      })
+    for (const block of streaming.contentBlocks) {
+      if (block.kind === 'text' && block.text) {
+        content.push({ type: 'text' as const, text: block.text })
+      } else if (block.kind === 'tool') {
+        content.push({
+          type: 'toolCall' as const,
+          name: block.name,
+          id: block.id,
+        })
+      }
     }
-    // Add text
-    content.push({ type: 'text' as const, text: streaming.text })
+
+    if (content.length === 0) return null
+
     return {
       role: 'assistant',
       content,
@@ -304,7 +310,7 @@ export function ChatScreen({
       __streaming: true,
       timestamp: Date.now(),
     } as GatewayMessage
-  }, [streaming.text, streaming.tools])
+  }, [streaming.contentBlocks])
 
   // Merge streaming message into display messages
   const messagesWithStreaming = useMemo(() => {
@@ -330,7 +336,15 @@ export function ChatScreen({
     if (assistantIsLatestTurn && typeof lastAssistantIndex === 'number') {
       const historyAssistant = displayMessages[lastAssistantIndex]
       const historyText = textFromMessage(historyAssistant)
-      if (historyText.length >= streaming.text.length) return displayMessages
+      // Only suppress the streaming overlay once history text has caught up
+      // AND there are no active tool-call indicators (tool-only responses
+      // have streaming.text === '' but should still show their tool cards).
+      if (
+        historyText.length >= streaming.text.length &&
+        streaming.tools.length === 0
+      ) {
+        return displayMessages
+      }
 
       const msgs = [...displayMessages]
       msgs[lastAssistantIndex] = streamingMessage
@@ -339,7 +353,7 @@ export function ChatScreen({
 
     // No assistant response for the current turn in history yet — append streaming.
     return [...displayMessages, streamingMessage]
-  }, [displayMessages, streamingMessage, streaming.text])
+  }, [displayMessages, streamingMessage, streaming.text, streaming.tools])
 
   const stableContentStyle = useMemo<React.CSSProperties>(() => ({}), [])
   refreshHistoryRef.current = function refreshHistory() {

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -161,9 +161,10 @@ export function ChatScreen({
   const gatewayStatusQuery = useQuery({
     queryKey: ['gateway', 'status'],
     queryFn: fetchGatewayStatus,
-    retry: false,
+    retry: 2,
+    retryDelay: (attempt) => Math.min(2000 * 2 ** attempt, 8000),
     refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    refetchOnReconnect: true,
     refetchOnMount: 'always',
   })
   const gatewayStatusMountRef = useRef(Date.now())
@@ -178,6 +179,15 @@ export function ChatScreen({
     void gatewayStatusQuery.refetch()
   }, [gatewayStatusQuery])
   const isSidebarCollapsed = uiQuery.data?.isSidebarCollapsed ?? false
+
+  // Auto-clear stale gateway errors: if sessions loaded successfully after
+  // the ping failed, the gateway is obviously reachable — refetch the status
+  // so the error state gets cleared properly.
+  useEffect(() => {
+    if (sessionsQuery.isSuccess && gatewayStatusQuery.isError) {
+      void gatewayStatusQuery.refetch()
+    }
+  }, [sessionsQuery.isSuccess, gatewayStatusQuery.isError]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sidebar edge-swipe gesture (mobile only)
   const sidebarSwipeHandlers = useSwipeGesture({
@@ -1004,8 +1014,11 @@ export function ChatScreen({
   const historyLoading =
     (historyQuery.isLoading && !historyQuery.data) || isRedirecting
   const showGatewayDown = Boolean(gatewayStatusError)
+  // Don't show the gateway notice if sessions have loaded successfully —
+  // that proves the gateway is reachable regardless of the ping result.
   const showGatewayNotice =
     showGatewayDown &&
+    !sessionsQuery.isSuccess &&
     gatewayStatusQuery.errorUpdatedAt > gatewayStatusMountRef.current
   const historyEmpty = !historyLoading && displayMessages.length === 0
   const gatewayNotice = useMemo(() => {

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -307,6 +307,7 @@ export function ChatScreen({
           type: 'toolCall' as const,
           name: block.name,
           id: block.id,
+          arguments: block.arguments,
         })
       }
     }
@@ -320,6 +321,26 @@ export function ChatScreen({
       __streaming: true,
       timestamp: Date.now(),
     } as GatewayMessage
+  }, [streaming.contentBlocks])
+
+  // Build synthetic tool-result messages for streaming tools that have completed.
+  // These are placed in the message array so `toolResultsByCallId` picks them
+  // up and the Tool component renders them with a ✓ checkmark + output.
+  const streamingToolResults = useMemo(() => {
+    const results: GatewayMessage[] = []
+    for (const block of streaming.contentBlocks) {
+      if (block.kind === 'tool' && block.status === 'done') {
+        results.push({
+          role: 'toolResult',
+          toolCallId: block.id,
+          toolName: block.name,
+          content: block.output
+            ? [{ type: 'text' as const, text: block.output }]
+            : [],
+        } as GatewayMessage)
+      }
+    }
+    return results
   }, [streaming.contentBlocks])
 
   // Merge streaming message into display messages
@@ -350,6 +371,7 @@ export function ChatScreen({
       return displayMessages
     }
 
+    let merged: GatewayMessage[]
     if (assistantIsLatestTurn && typeof lastAssistantIndex === 'number') {
       const historyAssistant = displayMessages[lastAssistantIndex]
       const historyText = textFromMessage(historyAssistant)
@@ -363,14 +385,21 @@ export function ChatScreen({
         return displayMessages
       }
 
-      const msgs = [...displayMessages]
-      msgs[lastAssistantIndex] = streamingMessage
-      return msgs
+      merged = [...displayMessages]
+      merged[lastAssistantIndex] = streamingMessage
+    } else {
+      // No assistant response for the current turn in history yet — append streaming.
+      merged = [...displayMessages, streamingMessage]
     }
 
-    // No assistant response for the current turn in history yet — append streaming.
-    return [...displayMessages, streamingMessage]
-  }, [displayMessages, streamingMessage, streaming.active, streaming.text, streaming.tools])
+    // Append synthetic tool-result messages so the Tool component can show
+    // completed tools with ✓ and output instead of a permanent spinner.
+    if (streamingToolResults.length > 0) {
+      merged = [...merged, ...streamingToolResults]
+    }
+
+    return merged
+  }, [displayMessages, streamingMessage, streamingToolResults, streaming.active, streaming.text, streaming.tools])
 
   const stableContentStyle = useMemo<React.CSSProperties>(() => ({}), [])
   refreshHistoryRef.current = function refreshHistory() {

--- a/src/screens/chat/hooks/use-streaming.ts
+++ b/src/screens/chat/hooks/use-streaming.ts
@@ -57,6 +57,10 @@ export function useStreaming(options: {
   const doneRef = useRef(false)
   const finalStateRef = useRef(false)
   const activeRunsRef = useRef(new Set<string>())
+  // Seq-based deduplication: gateway events carry an incrementing seq number.
+  // If we see a seq we've already processed, skip it. This guards against
+  // duplicate delivery caused by Vite SSR multi-context dispatch or similar.
+  const lastSeqRef = useRef(-1)
   // Track whether we've ever seen a run, to avoid premature onDone when
   // activeRuns is empty simply because no agent events arrived yet.
   const anyRunSeenRef = useRef(false)
@@ -79,6 +83,7 @@ export function useStreaming(options: {
     finalStateRef.current = false
     activeRunsRef.current.clear()
     anyRunSeenRef.current = false
+    lastSeqRef.current = -1
     if (eventSourceRef.current) {
       eventSourceRef.current.close()
       eventSourceRef.current = null
@@ -120,6 +125,7 @@ export function useStreaming(options: {
     finalStateRef.current = false
     activeRunsRef.current.clear()
     anyRunSeenRef.current = false
+    lastSeqRef.current = -1
 
     setState({
       active: true,
@@ -141,6 +147,13 @@ export function useStreaming(options: {
     es.addEventListener('message', (e) => {
       try {
         const data = JSON.parse(e.data) as RawGatewayEvent
+
+        // Seq-based deduplication: skip events we've already processed.
+        if (typeof data.seq === 'number') {
+          if (data.seq <= lastSeqRef.current) return
+          lastSeqRef.current = data.seq
+        }
+
         // Read the latest session key from the ref, NOT the closure.
         const currentKey = sessionKeyRef.current
 

--- a/src/screens/chat/hooks/use-streaming.ts
+++ b/src/screens/chat/hooks/use-streaming.ts
@@ -10,7 +10,14 @@ import {
 
 export type StreamContentBlock =
   | { kind: 'text'; text: string }
-  | { kind: 'tool'; name: string; id: string; status: string }
+  | {
+      kind: 'tool'
+      name: string
+      id: string
+      status: string
+      arguments?: Record<string, unknown>
+      output?: string
+    }
 
 export type StreamingState = {
   active: boolean
@@ -308,6 +315,18 @@ function handleAgentEvent(
     'Tool'
   const toolStatus = deriveToolStatus(stream, streamData)
 
+  // Extract tool input (arguments) and output from the event data.
+  // Gateway events may carry these under various field names.
+  const toolArgs =
+    asRecord(streamData?.arguments) ||
+    asRecord(streamData?.input) ||
+    asRecord(streamData?.params) ||
+    null
+  const toolOutput =
+    normalizeString(streamData?.result) ||
+    normalizeString(streamData?.output) ||
+    (stream.includes('result') ? normalizeString(streamData?.text) : '')
+
   options.setState((prev) => {
     // Update tools array (backward compat)
     const tools = [...prev.tools]
@@ -324,11 +343,17 @@ function handleAgentEvent(
     const blockIndex = blocks.findIndex(
       (b) => b.kind === 'tool' && b.id === toolId,
     )
+    const existingBlock = blockIndex >= 0
+      ? (blocks[blockIndex] as StreamContentBlock & { kind: 'tool' })
+      : null
     const nextBlock: StreamContentBlock = {
       kind: 'tool',
       name: toolName,
       id: toolId,
       status: toolStatus,
+      // Merge: keep existing arguments/output if new event doesn't carry them
+      arguments: toolArgs ?? existingBlock?.arguments,
+      output: toolOutput || existingBlock?.output || undefined,
     }
     if (blockIndex >= 0) {
       blocks[blockIndex] = nextBlock

--- a/src/screens/chat/hooks/use-streaming.ts
+++ b/src/screens/chat/hooks/use-streaming.ts
@@ -6,10 +6,20 @@ import {
   type SetStateAction,
 } from 'react'
 
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export type StreamContentBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'tool'; name: string; id: string; status: string }
+
 export type StreamingState = {
   active: boolean
+  /** Full accumulated assistant text (derived from contentBlocks). */
   text: string
+  /** Tool invocations (derived from contentBlocks, for backward compat). */
   tools: Array<{ name: string; status: string; id: string }>
+  /** Ordered content blocks — preserves the interleaving of text and tools. */
+  contentBlocks: StreamContentBlock[]
   sessionKey: string | null
 }
 
@@ -31,8 +41,11 @@ const INITIAL_STATE: StreamingState = {
   active: false,
   text: '',
   tools: [],
+  contentBlocks: [],
   sessionKey: null,
 }
+
+// ─── Hook ───────────────────────────────────────────────────────────────
 
 export function useStreaming(options: {
   onDone: (sessionKey: string) => void
@@ -44,6 +57,12 @@ export function useStreaming(options: {
   const doneRef = useRef(false)
   const finalStateRef = useRef(false)
   const activeRunsRef = useRef(new Set<string>())
+  // Track whether we've ever seen a run, to avoid premature onDone when
+  // activeRuns is empty simply because no agent events arrived yet.
+  const anyRunSeenRef = useRef(false)
+  // Mutable ref for the current session key so the long-lived EventSource
+  // message handler always reads the latest value (avoids stale closure).
+  const sessionKeyRef = useRef('')
   const onDoneRef = useRef(options.onDone)
   const onErrorRef = useRef(options.onError)
   const onAssistantDeltaRef = useRef(options.onAssistantDelta)
@@ -51,10 +70,15 @@ export function useStreaming(options: {
   onErrorRef.current = options.onError
   onAssistantDeltaRef.current = options.onAssistantDelta
 
+  /**
+   * Full teardown — closes the EventSource and resets all state.
+   * Used when navigating away from a chat session.
+   */
   const stop = useCallback((options?: { preserveState?: boolean }) => {
     doneRef.current = true
     finalStateRef.current = false
     activeRunsRef.current.clear()
+    anyRunSeenRef.current = false
     if (eventSourceRef.current) {
       eventSourceRef.current.close()
       eventSourceRef.current = null
@@ -66,35 +90,66 @@ export function useStreaming(options: {
     setState(INITIAL_STATE)
   }, [])
 
+  /**
+   * Start (or resume) streaming for a session.
+   *
+   * If an EventSource is already open and actively streaming (`doneRef` is
+   * false), the call is treated as a key-update (e.g. the second
+   * `startStream(resolvedKey)` after the send response) — state is NOT
+   * reset so in-flight deltas are preserved.
+   *
+   * If the EventSource exists but the previous message is done, state is
+   * reset for the new message while reusing the existing EventSource.
+   *
+   * If no EventSource exists, a fresh one is created.
+   */
   const start = useCallback(function start(sessionKey: string) {
+    // Always keep the ref up to date so the EventSource handler reads the
+    // latest key regardless of which call path we take.
+    sessionKeyRef.current = sessionKey
+
+    // ── Case 1: EventSource open & actively streaming ─────────────
+    // Second startStream call (resolved key) — just update the key.
+    if (eventSourceRef.current && !doneRef.current) {
+      setState((prev) => ({ ...prev, sessionKey, active: true }))
+      return
+    }
+
+    // ── Case 2 & 3: Need a fresh message state ───────────────────
     doneRef.current = false
     finalStateRef.current = false
     activeRunsRef.current.clear()
+    anyRunSeenRef.current = false
 
     setState({
       active: true,
       text: '',
       tools: [],
+      contentBlocks: [],
       sessionKey,
     })
 
-    // If we already have an open EventSource for this session, reuse it.
-    // The server stream stays open across multiple messages.
+    // Case 2: EventSource exists but was done — reuse it.
     if (eventSourceRef.current) {
       return
     }
 
+    // ── Case 3: Create a fresh EventSource ────────────────────────
     const es = new EventSource(`/api/stream?sessionKey=${encodeURIComponent(sessionKey)}`)
     eventSourceRef.current = es
 
     es.addEventListener('message', (e) => {
       try {
         const data = JSON.parse(e.data) as RawGatewayEvent
+        // Read the latest session key from the ref, NOT the closure.
+        const currentKey = sessionKeyRef.current
+
         if (data.event === 'agent') {
-          handleAgentEvent(data.payload, sessionKey, {
+          handleAgentEvent(data.payload, currentKey, {
             setState,
             onAssistantDelta: onAssistantDeltaRef.current,
             activeRuns: activeRunsRef.current,
+            anyRunSeen: anyRunSeenRef,
           })
           return
         }
@@ -102,17 +157,24 @@ export function useStreaming(options: {
         if (data.event === 'chat') {
           const chatPayload = asRecord(data.payload)
           const eventSessionKey =
-            normalizeString(chatPayload?.sessionKey) || sessionKey
+            normalizeString(chatPayload?.sessionKey) || currentKey
           const chatState = normalizeString(chatPayload?.state)
 
           if (chatState === 'final') {
             finalStateRef.current = true
           }
 
+          // Only fire onDone when:
+          // 1. We haven't already fired it (doneRef)
+          // 2. We've received a final chat state
+          // 3. Either chatState is 'final' now, OR all known runs have
+          //    ended (but only if we've seen at least one run, to avoid
+          //    premature completion before any agent events arrive).
           if (
             !doneRef.current &&
             finalStateRef.current &&
-            (chatState === 'final' || activeRunsRef.current.size === 0)
+            (chatState === 'final' ||
+              (anyRunSeenRef.current && activeRunsRef.current.size === 0))
           ) {
             doneRef.current = true
             // Don't close the EventSource — keep it alive for subsequent
@@ -149,6 +211,8 @@ export function useStreaming(options: {
   return { streaming: state, startStream: start, stopStream: stop }
 }
 
+// ─── Event Handling ─────────────────────────────────────────────────────
+
 function handleAgentEvent(
   payload: unknown,
   fallbackSessionKey: string,
@@ -156,6 +220,7 @@ function handleAgentEvent(
     setState: Dispatch<SetStateAction<StreamingState>>
     onAssistantDelta?: (payload: { text: string; sessionKey: string }) => void
     activeRuns: Set<string>
+    anyRunSeen: { current: boolean }
   },
 ) {
   const agentPayload = asRecord(payload) as RawAgentPayload | null
@@ -165,6 +230,7 @@ function handleAgentEvent(
   const streamData = asRecord(agentPayload?.data)
 
   if (runId) {
+    options.anyRunSeen.current = true
     if (stream === 'lifecycle') {
       const phase = normalizeString(streamData?.phase)
       if (phase === 'end' || phase === 'error' || phase === 'abort') {
@@ -177,18 +243,31 @@ function handleAgentEvent(
     }
   }
 
+  // ── Assistant text deltas ─────────────────────────────────────────
   if (stream === 'assistant') {
     const text = normalizeString(streamData?.delta) || normalizeString(streamData?.text)
     if (!text) return
-    options.setState((prev) => ({
-      ...prev,
-      sessionKey,
-      text: prev.text + text,
-    }))
+    options.setState((prev) => {
+      // Append to the last text block, or create a new one
+      const blocks = [...prev.contentBlocks]
+      const lastBlock = blocks[blocks.length - 1]
+      if (lastBlock?.kind === 'text') {
+        blocks[blocks.length - 1] = { ...lastBlock, text: lastBlock.text + text }
+      } else {
+        blocks.push({ kind: 'text', text })
+      }
+      return {
+        ...prev,
+        sessionKey,
+        text: prev.text + text,
+        contentBlocks: blocks,
+      }
+    })
     options.onAssistantDelta?.({ text, sessionKey })
     return
   }
 
+  // ── Tool events ───────────────────────────────────────────────────
   if (!stream.includes('tool')) return
 
   const toolId =
@@ -203,21 +282,43 @@ function handleAgentEvent(
   const toolStatus = deriveToolStatus(stream, streamData)
 
   options.setState((prev) => {
+    // Update tools array (backward compat)
     const tools = [...prev.tools]
-    const index = tools.findIndex((tool) => tool.id === toolId)
+    const toolIndex = tools.findIndex((tool) => tool.id === toolId)
     const nextTool = { id: toolId, name: toolName, status: toolStatus }
-    if (index >= 0) {
-      tools[index] = nextTool
+    if (toolIndex >= 0) {
+      tools[toolIndex] = nextTool
     } else {
       tools.push(nextTool)
     }
+
+    // Update contentBlocks — preserves interleaving order
+    const blocks = [...prev.contentBlocks]
+    const blockIndex = blocks.findIndex(
+      (b) => b.kind === 'tool' && b.id === toolId,
+    )
+    const nextBlock: StreamContentBlock = {
+      kind: 'tool',
+      name: toolName,
+      id: toolId,
+      status: toolStatus,
+    }
+    if (blockIndex >= 0) {
+      blocks[blockIndex] = nextBlock
+    } else {
+      blocks.push(nextBlock)
+    }
+
     return {
       ...prev,
       sessionKey,
       tools,
+      contentBlocks: blocks,
     }
   })
 }
+
+// ─── Helpers ────────────────────────────────────────────────────────────
 
 function deriveToolStatus(stream: string, data: Record<string, unknown> | null): string {
   const explicitStatus =

--- a/src/screens/chat/hooks/use-streaming.ts
+++ b/src/screens/chat/hooks/use-streaming.ts
@@ -61,6 +61,11 @@ export function useStreaming(options: {
   // If we see a seq we've already processed, skip it. This guards against
   // duplicate delivery caused by Vite SSR multi-context dispatch or similar.
   const lastSeqRef = useRef(-1)
+  // Content-based deduplication: if consecutive agent events have identical
+  // payloads (same event type + same data), skip the duplicate. This catches
+  // cases where duplicated events carry *different* seq values (e.g. two WS
+  // connections each forwarding the same gateway event with their own seq).
+  const lastAgentFingerprintRef = useRef('')
   // Track whether we've ever seen a run, to avoid premature onDone when
   // activeRuns is empty simply because no agent events arrived yet.
   const anyRunSeenRef = useRef(false)
@@ -84,6 +89,7 @@ export function useStreaming(options: {
     activeRunsRef.current.clear()
     anyRunSeenRef.current = false
     lastSeqRef.current = -1
+    lastAgentFingerprintRef.current = ''
     if (eventSourceRef.current) {
       eventSourceRef.current.close()
       eventSourceRef.current = null
@@ -126,6 +132,7 @@ export function useStreaming(options: {
     activeRunsRef.current.clear()
     anyRunSeenRef.current = false
     lastSeqRef.current = -1
+    lastAgentFingerprintRef.current = ''
 
     setState({
       active: true,
@@ -158,6 +165,13 @@ export function useStreaming(options: {
         const currentKey = sessionKeyRef.current
 
         if (data.event === 'agent') {
+          // Content-based dedup: skip consecutive agent events with identical
+          // payloads. Catches duplicates that have *different* seq values
+          // (e.g. from parallel WS connections or Vite SSR multi-context).
+          const fp = JSON.stringify(data.payload)
+          if (fp === lastAgentFingerprintRef.current) return
+          lastAgentFingerprintRef.current = fp
+
           handleAgentEvent(data.payload, currentKey, {
             setState,
             onAssistantDelta: onAssistantDeltaRef.current,

--- a/src/server/gateway.ts
+++ b/src/server/gateway.ts
@@ -395,6 +395,9 @@ class PersistentGatewayConnection {
       const timer = setTimeout(() => {
         if (done) return
         done = true
+        // Clean up the handler to prevent leaking an extra message listener
+        // on the WebSocket (would be harmless but wastes cycles on every frame).
+        ws.off('message', onMessage)
         resolve('')
       }, 3000)
 

--- a/src/server/gateway.ts
+++ b/src/server/gateway.ts
@@ -47,6 +47,7 @@ export type GatewayEvent = {
   event: string
   payload: Record<string, unknown>
   seq?: number
+  stateVersion?: number
 }
 
 export type StreamListener = (event: GatewayEvent) => void
@@ -56,21 +57,14 @@ type GatewayClientCallbacks = {
   onError?: (error: Error) => void
 }
 
-type GatewayClient = {
-  connect: () => Promise<void>
-  sendReq: <TPayload = unknown>(method: string, params?: unknown) => Promise<TPayload>
-  close: () => void
-  isClosed: () => boolean
-  addCallbacks: (callbacks?: GatewayClientCallbacks) => () => void
-}
-
-type GatewayClientEntry = {
-  refs: number
-  client: GatewayClient
-}
-
 type GatewayClientHandle = {
-  client: GatewayClient
+  client: {
+    connect: () => Promise<void>
+    sendReq: <TPayload = unknown>(method: string, params?: unknown) => Promise<TPayload>
+    close: () => void
+    isClosed: () => boolean
+    addCallbacks: (callbacks?: GatewayClientCallbacks) => () => void
+  }
   release: () => void
 }
 
@@ -539,6 +533,9 @@ class PersistentGatewayConnection {
           event: parsed.event,
           payload: (parsed.payload ?? {}) as Record<string, unknown>,
           seq: parsed.seq,
+          stateVersion: typeof (parsed as any).stateVersion === 'number'
+            ? (parsed as any).stateVersion
+            : undefined,
         }
 
         // Determine which sessionKey this event belongs to
@@ -549,14 +546,23 @@ class PersistentGatewayConnection {
           try { listener(event) } catch {}
         }
 
-        // Notify session-specific listeners
+        // Notify session-specific listeners (segment match: event sessionKey
+        // may be 'agent:main:main' while subscription key is 'main').
+        // We split on ':' and check if any segment equals the subscription key,
+        // avoiding false positives from plain substring matching.
         if (sessionKey) {
-          const listeners = this.sessionListeners.get(sessionKey)
-          if (listeners && listeners.size > 0) {
-            for (const listener of listeners) {
-              try { listener(event) } catch {}
+          let dispatched = false
+          const eventSegments = sessionKey.split(':')
+          for (const [subKey, listeners] of this.sessionListeners) {
+            if (sessionKey === subKey || eventSegments.includes(subKey)) {
+              dispatched = true
+              for (const listener of listeners) {
+                try { listener(event) } catch {}
+              }
             }
-          } else {
+          }
+
+          if (!dispatched) {
             // No listeners yet — buffer the event so late subscribers can catch up
             let buf = this.eventBuffer.get(sessionKey)
             if (!buf) {
@@ -653,13 +659,21 @@ class PersistentGatewayConnection {
     }
     listeners.add(listener)
 
-    // Flush any buffered events to the new subscriber
-    const buf = this.eventBuffer.get(sessionKey)
-    if (buf) {
-      this.eventBuffer.delete(sessionKey)
-      clearTimeout(buf.timer)
-      for (const event of buf.events) {
-        try { listener(event) } catch {}
+    // Flush any buffered events that match this subscription (segment match)
+    const keysToFlush: string[] = []
+    for (const bufKey of this.eventBuffer.keys()) {
+      if (bufKey === sessionKey || bufKey.split(':').includes(sessionKey)) {
+        keysToFlush.push(bufKey)
+      }
+    }
+    for (const bufKey of keysToFlush) {
+      const buf = this.eventBuffer.get(bufKey)
+      if (buf) {
+        this.eventBuffer.delete(bufKey)
+        clearTimeout(buf.timer)
+        for (const event of buf.events) {
+          try { listener(event) } catch {}
+        }
       }
     }
 
@@ -712,246 +726,36 @@ function getPersistentConnection(): PersistentGatewayConnection {
 }
 
 
-const sharedGatewayClients = new Map<string, GatewayClientEntry>()
-
-function createGatewayClient(): GatewayClient {
-  const pendingRpcs = new Map<string, PendingRpc>()
-  const callbacks = new Set<GatewayClientCallbacks>()
-  let ws: WebSocket | null = null
-  let closed = false
-  let connected = false
-  let connectPromise: Promise<void> | null = null
-
-  function rejectAll(err: Error) {
-    for (const [, pending] of pendingRpcs) {
-      clearTimeout(pending.timer)
-      pending.reject(err)
-    }
-    pendingRpcs.clear()
-  }
-
-  function waitForRes(id: string, timeoutMs = 30_000): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        pendingRpcs.delete(id)
-        reject(new Error(`RPC timeout waiting for ${id}`))
-      }, timeoutMs)
-      pendingRpcs.set(id, { resolve, reject, timer })
-    })
-  }
-
-  function emitError(error: Error) {
-    for (const callback of callbacks) {
-      try {
-        callback.onError?.(error)
-      } catch {}
-    }
-  }
-
-  function emitEvent(event: GatewayEvent) {
-    for (const callback of callbacks) {
-      try {
-        callback.onEvent?.(event)
-      } catch {}
-    }
-  }
-
-  function handleMessage(data: WebSocket.Data) {
-    try {
-      const str = typeof data === 'string' ? data : data.toString()
-      const parsed = JSON.parse(str) as GatewayFrame
-
-      if (parsed.type === 'res') {
-        const pending = pendingRpcs.get(parsed.id)
-        if (!pending) return
-        pendingRpcs.delete(parsed.id)
-        clearTimeout(pending.timer)
-        if (parsed.ok) pending.resolve(parsed.payload)
-        else pending.reject(new GatewayResponseError(parsed.error?.message ?? 'gateway error', parsed.error?.code))
-        return
-      }
-
-      if (parsed.type === 'event') {
-        emitEvent({
-          event: parsed.event,
-          payload: (parsed.payload ?? {}) as Record<string, unknown>,
-          seq: parsed.seq,
-        })
-      }
-    } catch {
-      // Ignore parse errors
-    }
-  }
-
-  function handleClose() {
-    const wasConnected = connected
-    connected = false
-    ws = null
-    rejectAll(new Error('Connection closed'))
-    if (!closed && wasConnected) {
-      emitError(new Error('Gateway client connection closed'))
-    }
-  }
-
-  async function connect(): Promise<void> {
-    if (closed) throw new Error('Gateway client closed')
-    if (connected && ws?.readyState === WebSocket.OPEN) return
-    if (connectPromise) return connectPromise
-
-    connectPromise = (async () => {
-      const { url, token, password } = getGatewayConfig()
-      const origin = process.env.OPENCAMI_ORIGIN?.trim()
-      const nextWs = origin
-        ? new WebSocket(url, { headers: { Origin: origin } })
-        : new WebSocket(url)
-
-      ws = nextWs
-
-      await new Promise<void>((resolve, reject) => {
-        const onOpen = () => { cleanup(); resolve() }
-        const onError = (err: Error) => { cleanup(); reject(new Error(`WS open error: ${err.message}`)) }
-        const cleanup = () => { nextWs.off('open', onOpen); nextWs.off('error', onError) }
-        nextWs.on('open', onOpen)
-        nextWs.on('error', onError)
-      })
-
-      const nonce = await new Promise<string>((resolve) => {
-        let done = false
-        const timer = setTimeout(() => {
-          if (done) return
-          done = true
-          resolve('')
-        }, 3000)
-
-        const onMessage = (data: WebSocket.Data) => {
-          try {
-            const str = typeof data === 'string' ? data : data.toString()
-            const parsed = JSON.parse(str) as GatewayFrame
-            if (parsed.type === 'event' && parsed.event === 'connect.challenge') {
-              const n = (parsed.payload as any)?.nonce
-              if (typeof n === 'string' && n.length > 0) {
-                clearTimeout(timer)
-                nextWs.off('message', onMessage)
-                if (done) return
-                done = true
-                resolve(n)
-              }
-            }
-          } catch {}
-        }
-
-        nextWs.on('message', onMessage)
-      })
-
-      nextWs.on('message', handleMessage)
-      nextWs.on('close', handleClose)
-      nextWs.on('error', (err: Error) => {
-        emitError(new Error(`Gateway client error: ${err.message}`))
-      })
-
-      const connectId = randomUUID()
-      const connectParams = buildConnectParams(url, token, password, nonce)
-      nextWs.send(JSON.stringify({
-        type: 'req',
-        id: connectId,
-        method: 'connect',
-        params: connectParams,
-      }))
-
-      const hello = await waitForRes(connectId, 10_000) as any
-      if (hello?.auth?.deviceToken) {
-        const identity = loadOrCreateDeviceIdentity()
-        storeDeviceToken(identity.deviceId, url, hello.auth.deviceToken)
-      }
-
-      connected = true
-    })()
-
-
-    try {
-      await connectPromise
-    } finally {
-      connectPromise = null
-    }
-  }
-
-  async function sendReq<TPayload = unknown>(method: string, params?: unknown): Promise<TPayload> {
-    await connect()
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      throw new Error('Gateway client not connected')
-    }
-    const id = randomUUID()
-    ws.send(JSON.stringify({ type: 'req', id, method, params }))
-    return await waitForRes(id) as TPayload
-  }
-
-  function close() {
-    if (closed) return
-    closed = true
-    connected = false
-    rejectAll(new Error('Gateway client closed'))
-    const currentWs = ws
-    ws = null
-    if (currentWs) {
-      currentWs.off('message', handleMessage)
-      currentWs.off('close', handleClose)
-      currentWs.close()
-    }
-    callbacks.clear()
-  }
-
-  function isClosed() {
-    return closed
-  }
-
-  function addCallbacks(callbacksToAdd?: GatewayClientCallbacks) {
-    if (!callbacksToAdd?.onEvent && !callbacksToAdd?.onError) {
-      return () => {}
-    }
-    callbacks.add(callbacksToAdd)
-    return () => {
-      callbacks.delete(callbacksToAdd)
-    }
-  }
-
-  return { connect, sendReq, close, isClosed, addCallbacks }
-}
-
-function releaseGatewayClient(key: string) {
-  const entry = sharedGatewayClients.get(key)
-  if (!entry) return
-  entry.refs -= 1
-  if (entry.refs > 0) return
-  entry.client.close()
-  sharedGatewayClients.delete(key)
-}
+// ─── Unified Gateway Client ─────────────────────────────────────────────
+//
+// All streaming and RPC now goes through the single PersistentGatewayConnection.
+// This eliminates the connId mismatch bug: chat.send and event streaming always
+// share the same WS connection, so the gateway always routes events correctly.
+//
 
 export async function acquireGatewayClient(
   key: string,
   callbacks?: GatewayClientCallbacks,
 ): Promise<GatewayClientHandle> {
-  const existing = sharedGatewayClients.get(key)
-  if (existing && !existing.client.isClosed()) {
-    existing.refs += 1
-    const removeCallbacks = existing.client.addCallbacks(callbacks)
-    return {
-      client: existing.client,
-      release: () => {
-        removeCallbacks()
-        releaseGatewayClient(key)
-      },
-    }
+  const conn = getPersistentConnection()
+  await conn.ensureConnected()
+
+  let unsubscribe: (() => void) | null = null
+  if (callbacks?.onEvent) {
+    unsubscribe = conn.subscribe(key, callbacks.onEvent)
   }
 
-  const client = createGatewayClient()
-  const removeCallbacks = client.addCallbacks(callbacks)
-  await client.connect()
-  sharedGatewayClients.set(key, { refs: 1, client })
   return {
-    client,
+    client: {
+      connect: () => conn.ensureConnected(),
+      sendReq: <TPayload = unknown>(method: string, params?: unknown) =>
+        conn.rpc<TPayload>(method, params),
+      close: () => { /* no-op: persistent connection stays open */ },
+      isClosed: () => !conn.isConnected,
+      addCallbacks: () => () => {},
+    },
     release: () => {
-      removeCallbacks()
-      releaseGatewayClient(key)
+      unsubscribe?.()
     },
   }
 }
@@ -959,18 +763,11 @@ export async function acquireGatewayClient(
 export async function gatewayRpcShared<TPayload = unknown>(
   method: string,
   params?: unknown,
-  key?: string,
+  _key?: string,
 ): Promise<TPayload> {
-  if (!key) {
-    return gatewayRpc<TPayload>(method, params)
-  }
-
-  const existing = sharedGatewayClients.get(key)
-  if (!existing || existing.client.isClosed()) {
-    return gatewayRpc<TPayload>(method, params)
-  }
-
-  return existing.client.sendReq<TPayload>(method, params)
+  // All RPCs now go through the single persistent connection.
+  // The _key parameter is kept for API compatibility but ignored.
+  return gatewayRpc<TPayload>(method, params)
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Unified gateway connection**: Single `PersistentGatewayConnection` singleton (on `process`) eliminates duplicate WS connections in Vite SSR contexts
- **Three-layer event deduplication**: seq-based → content-based fingerprinting → merge guard (prefers persisted history after streaming ends)
- **Gateway unreachable notice**: Increased ping timeout (2.5s→8s), added retry with backoff, auto-dismiss when sessions load successfully
- **Tool cards during streaming**: Extended `StreamContentBlock` with `arguments`/`output`, synthetic `toolResult` messages for completed tools so Tool component renders input/output instead of empty cards
- **Nonce handler leak fix**: Properly remove WS message listener on timeout in gateway handshake

## Test plan
- [ ] Send a message and verify streaming text is not doubled/garbled
- [ ] Verify text is correct after streaming completes (merge guard)
- [ ] Verify tool calls show arguments and output during streaming
- [ ] Verify tool calls show ✓ checkmark + output after completion
- [ ] Verify "Gateway unreachable" notice does not persist when gateway is connected
- [ ] Verify EventSource stays open between messages in the same chat
- [ ] Test session switching — streaming state should reset cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)