### PR TITLE
fix: request operator.read and operator.write scopes during pairing

### DIFF
--- a/src/server/gateway.ts
+++ b/src/server/gateway.ts
@@ -244,7 +244,7 @@ function buildConnectParams(url: string, token: string, password: string, nonce:
   const clientId = 'openclaw-control-ui'
   const clientMode = 'webchat'
   const role = 'operator'
-  const scopes = ['operator.admin', 'operator.approvals', 'operator.pairing']
+  const scopes = ['operator.read', 'operator.write', 'operator.admin', 'operator.approvals', 'operator.pairing']
 
   if (!nonce) {
     throw new Error(
@@ -489,7 +489,7 @@ class PersistentGatewayConnection {
           password: password || undefined,
         },
         role: 'operator',
-        scopes: ['operator.admin', 'operator.approvals', 'operator.pairing'],
+        scopes: ['operator.read', 'operator.write', 'operator.admin', 'operator.approvals', 'operator.pairing'],
         userAgent: `opencami/${process.env.npm_package_version ?? 'dev'} (node ${process.version})`,
         locale: process.env.LANG || 'en',
       }


### PR DESCRIPTION
## Summary
- Add `operator.read` and `operator.write` to the scopes requested during device pairing connect handshake
- Fixes both the primary `buildConnectParams` path and the device-auth fallback reconnect path
- The gateway does not implicitly grant these from `operator.admin` — they must be explicitly requested ([protocol docs](https://docs.openclaw.ai/gateway/protocol.md))

Closes #2

## Test plan
- [ ] Fresh pairing: delete `~/.opencami/identity/device-tokens.json`, restart, verify connection succeeds without the "missing required scope: operator.read" error
- [ ] Existing pairing: verify existing paired devices reconnect correctly
- [ ] Verify `chat.history`, `chat.send`, and other read/write RPCs work after pairing

🤖 Generated with [Claude Code](https://claude.com/claude-code)