### PR TITLE
improve: retry/dismiss UI for failed messages

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -959,6 +959,66 @@ export function ChatScreen({
     })
   }, [queryClient])
 
+  // Handle retry on a failed message — re-send the original text
+  const handleRetryMessage = useCallback(
+    (message: GatewayMessage) => {
+      const messageText = textFromMessage(message)
+      if (!messageText) return
+      const sessionKeyForSend =
+        forcedSessionKey || resolvedSessionKey || activeSessionKey
+      if (!sessionKeyForSend) return
+      // Remove the failed message from history
+      const clientId = message.clientId as string | undefined
+      const optimisticId = message.__optimisticId
+      if (clientId) {
+        removeHistoryMessageByClientId(
+          queryClient,
+          activeFriendlyId,
+          sessionKeyForSend,
+          clientId,
+          optimisticId,
+        )
+      }
+      // Re-send
+      sendMessage(sessionKeyForSend, activeFriendlyId, messageText)
+    },
+    [
+      activeFriendlyId,
+      activeSessionKey,
+      forcedSessionKey,
+      queryClient,
+      resolvedSessionKey,
+    ],
+  )
+
+  // Handle dismiss on a failed message — remove it from history
+  const handleDismissMessage = useCallback(
+    (message: GatewayMessage) => {
+      const sessionKeyForSend =
+        forcedSessionKey || resolvedSessionKey || activeSessionKey
+      if (!sessionKeyForSend) return
+      const clientId = message.clientId as string | undefined
+      const optimisticId = message.__optimisticId
+      if (clientId) {
+        removeHistoryMessageByClientId(
+          queryClient,
+          activeFriendlyId,
+          sessionKeyForSend,
+          clientId,
+          optimisticId,
+        )
+      }
+      setError(null)
+    },
+    [
+      activeFriendlyId,
+      activeSessionKey,
+      forcedSessionKey,
+      queryClient,
+      resolvedSessionKey,
+    ],
+  )
+
   // Handle follow-up suggestion clicks - sends the suggestion as a new message
   const handleFollowUpClick = useCallback(
     (suggestion: string) => {
@@ -1145,6 +1205,8 @@ export function ChatScreen({
                 contentStyle={stableContentStyle}
                 onFollowUpClick={handleFollowUpClick}
                 jumpToMessageId={searchJumpMessageId}
+                onRetryMessage={handleRetryMessage}
+                onDismissMessage={handleDismissMessage}
               />
               <ChatComposer
                 onSubmit={send}

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -83,6 +83,49 @@ type ChatScreenProps = {
   forcedSessionKey?: string
 }
 
+type SendAttachmentPayload = {
+  mimeType: string
+  content: string
+}
+
+function extractRetryImageAttachments(message: GatewayMessage): {
+  attachments: AttachmentFile[]
+  payload: SendAttachmentPayload[]
+} {
+  const parts = Array.isArray(message.content) ? message.content : []
+  const attachments: AttachmentFile[] = []
+  const payload: SendAttachmentPayload[] = []
+
+  for (const [index, part] of parts.entries()) {
+    if (
+      part.type !== 'image' ||
+      !('source' in part) ||
+      typeof part.source?.data !== 'string' ||
+      part.source.data.length === 0
+    ) {
+      continue
+    }
+
+    const mimeType =
+      typeof part.source?.media_type === 'string' &&
+      part.source.media_type.length > 0
+        ? part.source.media_type
+        : 'image/jpeg'
+    const content = part.source.data
+
+    attachments.push({
+      id: crypto.randomUUID(),
+      file: new File([], `retry-attachment-${index + 1}`, { type: mimeType }),
+      preview: null,
+      type: 'image',
+      base64: content,
+    })
+    payload.push({ mimeType, content })
+  }
+
+  return { attachments, payload }
+}
+
 export function ChatScreen({
   activeFriendlyId,
   isNewChat = false,
@@ -719,6 +762,7 @@ export function ChatScreen({
     skipOptimistic = false,
     attachments?: AttachmentFile[],
     model?: string,
+    retryAttachmentsPayload?: SendAttachmentPayload[],
   ) {
     let optimisticClientId = ''
     if (!skipOptimistic) {
@@ -748,10 +792,18 @@ export function ChatScreen({
     setPinToTop(true)
 
     // Build attachments payload for API (Gateway expects mimeType + content)
-    const attachmentsPayload = attachments?.map((a) => ({
-      mimeType: a.file.type,
-      content: a.base64,
-    }))
+    const attachmentsPayload =
+      retryAttachmentsPayload ??
+      attachments?.flatMap((a) =>
+        a.base64
+          ? [
+              {
+                mimeType: a.file.type,
+                content: a.base64,
+              },
+            ]
+          : [],
+      )
 
     // Start SSE streaming AFTER sending — use the resolved sessionKey from the
     // server response to avoid subscribing to the wrong key when activeSessionKey
@@ -959,15 +1011,18 @@ export function ChatScreen({
     })
   }, [queryClient])
 
-  // Handle retry on a failed message — re-send the original text
+  // Handle retry on a failed message — re-send the original text and images
   const handleRetryMessage = useCallback(
     (message: GatewayMessage) => {
       const messageText = textFromMessage(message)
-      if (!messageText) return
+      const {
+        attachments: retryAttachments,
+        payload: retryAttachmentsPayload,
+      } = extractRetryImageAttachments(message)
+      if (!messageText && retryAttachments.length === 0) return
       const sessionKeyForSend =
         forcedSessionKey || resolvedSessionKey || activeSessionKey
       if (!sessionKeyForSend) return
-      // Remove the failed message from history
       const clientId = message.clientId as string | undefined
       const optimisticId = message.__optimisticId
       if (clientId) {
@@ -979,8 +1034,15 @@ export function ChatScreen({
           optimisticId,
         )
       }
-      // Re-send
-      sendMessage(sessionKeyForSend, activeFriendlyId, messageText)
+      sendMessage(
+        sessionKeyForSend,
+        activeFriendlyId,
+        messageText,
+        false,
+        retryAttachments,
+        undefined,
+        retryAttachmentsPayload,
+      )
     },
     [
       activeFriendlyId,

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -45,6 +45,10 @@ type ChatMessageListProps = {
   onFollowUpClick?: (suggestion: string) => void
   /** Message id to scroll to and briefly highlight */
   jumpToMessageId?: string | null
+  /** Called when user clicks Retry on a failed message */
+  onRetryMessage?: (message: GatewayMessage) => void
+  /** Called when user clicks Dismiss on a failed message */
+  onDismissMessage?: (message: GatewayMessage) => void
 }
 
 function ChatMessageListComponent({
@@ -63,6 +67,8 @@ function ChatMessageListComponent({
   contentStyle,
   onFollowUpClick,
   jumpToMessageId,
+  onRetryMessage,
+  onDismissMessage,
 }: ChatMessageListProps) {
   const anchorRef = useRef<HTMLDivElement | null>(null)
   const lastUserRef = useRef<HTMLDivElement | null>(null)
@@ -364,6 +370,8 @@ function ChatMessageListComponent({
                       messageId ? `message-${messageId}` : undefined
                     }
                     highlighted={highlightedMessageId === messageId}
+                    onRetry={onRetryMessage}
+                    onDismiss={onDismissMessage}
                   />
                 )
               })}
@@ -416,6 +424,8 @@ function ChatMessageListComponent({
                         messageId ? `message-${messageId}` : undefined
                       }
                       highlighted={highlightedMessageId === messageId}
+                      onRetry={onRetryMessage}
+                      onDismiss={onDismissMessage}
                     />
                   )
                 })}
@@ -465,6 +475,8 @@ function ChatMessageListComponent({
                   }
                   messageDomId={messageId ? `message-${messageId}` : undefined}
                   highlighted={highlightedMessageId === messageId}
+                  onRetry={onRetryMessage}
+                  onDismiss={onDismissMessage}
                 />
               )
             })}
@@ -507,7 +519,9 @@ function areChatMessageListEqual(
     prev.headerHeight === next.headerHeight &&
     prev.contentStyle === next.contentStyle &&
     prev.onFollowUpClick === next.onFollowUpClick &&
-    prev.jumpToMessageId === next.jumpToMessageId
+    prev.jumpToMessageId === next.jumpToMessageId &&
+    prev.onRetryMessage === next.onRetryMessage &&
+    prev.onDismissMessage === next.onDismissMessage
   )
 }
 

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -44,6 +44,10 @@ type MessageItemProps = {
   wrapperScrollMarginTop?: number
   messageDomId?: string
   highlighted?: boolean
+  /** Called when the user clicks "Retry" on a failed message */
+  onRetry?: (message: GatewayMessage) => void
+  /** Called when the user clicks "Dismiss" on a failed message */
+  onDismiss?: (message: GatewayMessage) => void
 }
 
 function mapToolCallToToolPart(
@@ -303,6 +307,8 @@ function MessageItemComponent({
   wrapperScrollMarginTop,
   messageDomId,
   highlighted = false,
+  onRetry,
+  onDismiss,
 }: MessageItemProps) {
   const { settings } = useChatSettings()
   const role = message.role || 'assistant'
@@ -310,6 +316,7 @@ function MessageItemComponent({
   const thinking = thinkingFromMessage(message)
   const images = imagesFromMessage(message)
   const isUser = role === 'user'
+  const isFailed = isUser && (message as any).status === 'error'
   const imageDataUris = useMemo(
     () =>
       images.map(
@@ -480,11 +487,36 @@ function MessageItemComponent({
               ? 'opencami-message-user bg-primary-100 px-4 py-[var(--opencami-user-bubble-py)] max-w-[85%]'
               : 'opencami-message-assistant bg-transparent w-full',
             !isUser && isStreaming && 'stream-fade-in',
+            isFailed && 'opacity-60',
           )}
         >
           {displayText}
         </MessageContent>
       </Message>
+
+      {isFailed && (
+        <div className="flex items-center gap-2 text-xs text-red-500 dark:text-red-400">
+          <span>Failed to send</span>
+          {onRetry && (
+            <button
+              type="button"
+              className="underline hover:text-red-700 dark:hover:text-red-300"
+              onClick={() => onRetry(message)}
+            >
+              Retry
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              type="button"
+              className="underline hover:text-red-700 dark:hover:text-red-300"
+              onClick={() => onDismiss(message)}
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Render tool calls with their results */}
       {hasToolCalls && settings.showToolMessages && (
@@ -544,6 +576,9 @@ function areMessagesEqual(
   }
   if (prevProps.messageDomId !== nextProps.messageDomId) return false
   if (prevProps.highlighted !== nextProps.highlighted) return false
+  if (prevProps.onRetry !== nextProps.onRetry) return false
+  if (prevProps.onDismiss !== nextProps.onDismiss) return false
+  if ((prevProps.message as any).status !== (nextProps.message as any).status) return false
   if (
     (prevProps.message.role || 'assistant') !==
     (nextProps.message.role || 'assistant')


### PR DESCRIPTION
## Summary
- When `chat.send` fails, the optimistic user message now shows a **"Failed to send"** indicator with **Retry** and **Dismiss** buttons
- **Retry** extracts the original message text, removes the failed message, and re-sends
- **Dismiss** removes the failed message from history and clears the error banner
- Failed message bubble renders with reduced opacity to visually indicate the error state

## Test plan
- [ ] Disconnect gateway, send a message, verify "Failed to send · Retry · Dismiss" appears below the user bubble
- [ ] Click Retry — verify the message is re-sent (with a new optimistic message)
- [ ] Click Dismiss — verify the failed message is removed and error banner clears
- [ ] Verify normal messages are unaffected (no error indicator shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)