### PR TITLE
improve: paginated history loading (50 per page)

### DIFF
--- a/src/__tests__/hooks/use-chat-history.test.ts
+++ b/src/__tests__/hooks/use-chat-history.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeHistoryPage } from '@/screens/chat/hooks/use-chat-history'
+
+describe('normalizeHistoryPage', () => {
+  it('preserves hasMore when the API already inferred an exact-limit extra page', () => {
+    const messages = Array.from({ length: 50 }, (_, index) => ({ id: `m${index}` }))
+
+    const result = normalizeHistoryPage(
+      {
+        sessionKey: 'session',
+        messages: messages as any,
+        hasMore: true,
+      },
+      50,
+    )
+
+    expect(result.messages).toHaveLength(50)
+    expect(result.hasMore).toBe(true)
+  })
+
+  it('trims the extra record while keeping hasMore true', () => {
+    const messages = Array.from({ length: 51 }, (_, index) => ({ id: `m${index}` }))
+
+    const result = normalizeHistoryPage(
+      {
+        sessionKey: 'session',
+        messages: messages as any,
+      },
+      50,
+    )
+
+    expect(result.messages).toHaveLength(50)
+    expect(result.messages[0]).toEqual({ id: 'm1' })
+    expect(result.hasMore).toBe(true)
+  })
+})

--- a/src/__tests__/hooks/use-search-history.test.ts
+++ b/src/__tests__/hooks/use-search-history.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchEntireHistory, hasSufficientCachedHistory } from '@/hooks/use-search'
+import { fetchHistory } from '@/screens/chat/chat-queries'
+
+vi.mock('@/screens/chat/chat-queries', async () => {
+  return {
+    chatQueryKeys: {
+      history: (friendlyId: string, sessionKey: string) => [
+        'chat',
+        'history',
+        friendlyId,
+        sessionKey,
+      ],
+    },
+    fetchHistory: vi.fn(),
+  }
+})
+
+describe('use-search history helpers', () => {
+  const mockedFetchHistory = vi.mocked(fetchHistory)
+
+  beforeEach(() => {
+    mockedFetchHistory.mockReset()
+  })
+
+  it('requires the full-search threshold before reusing a complete cache', () => {
+    expect(hasSufficientCachedHistory([{ id: 'm1' } as any], false, true)).toBe(false)
+    expect(
+      hasSufficientCachedHistory(
+        Array.from({ length: 200 }, (_, index) => ({ id: `m${index}` } as any)),
+        false,
+        true,
+      ),
+    ).toBe(true)
+  })
+
+  it('breaks full-history fetches when a page adds nothing new', async () => {
+    mockedFetchHistory.mockResolvedValue({
+      sessionKey: 'session',
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          content: [{ type: 'text', text: 'hello' }],
+        } as any,
+      ],
+      hasMore: true,
+    })
+
+    const result = await fetchEntireHistory({
+      friendlyId: 'friendly',
+      sessionKey: 'session',
+      signal: new AbortController().signal,
+    })
+
+    expect(mockedFetchHistory).toHaveBeenCalledTimes(2)
+    expect(result.messages).toHaveLength(1)
+    expect(result.hasMore).toBe(false)
+  })
+
+  it('caps full-history fetches after 20 pages', async () => {
+    let counter = 0
+    mockedFetchHistory.mockImplementation(async () => {
+      counter += 1
+      return {
+        sessionKey: 'session',
+        messages: [
+          {
+            id: `m${counter}`,
+            role: 'user',
+            content: [{ type: 'text', text: `message ${counter}` }],
+          } as any,
+        ],
+        hasMore: true,
+      }
+    })
+
+    const result = await fetchEntireHistory({
+      friendlyId: 'friendly',
+      sessionKey: 'session',
+      signal: new AbortController().signal,
+    })
+
+    expect(mockedFetchHistory).toHaveBeenCalledTimes(20)
+    expect(result.messages).toHaveLength(20)
+    expect(result.hasMore).toBe(false)
+  })
+})

--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -71,11 +71,11 @@ export function SearchDialog({
 
     return () => window.clearTimeout(timer)
   }, [
-    clearSearch,
     localQuery,
     mode,
     searchAllSessions,
     searchCurrentConversation,
+    clearSearch,
   ])
 
   useEffect(() => {
@@ -137,99 +137,186 @@ export function SearchDialog({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (results.length === 0) return
-
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        setSelectedIndex((prev) => Math.min(prev + 1, results.length - 1))
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        setSelectedIndex((prev) => Math.max(prev - 1, 0))
-      } else if (e.key === 'Enter') {
-        e.preventDefault()
-        const result = results[selectedIndex]
-        if (result) handleSelectResult(result)
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setSelectedIndex((i) => Math.min(i + 1, results.length - 1))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setSelectedIndex((i) => Math.max(i - 1, 0))
+          break
+        case 'Enter':
+          e.preventDefault()
+          if (results[selectedIndex]) {
+            handleSelectResult(results[selectedIndex])
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          onOpenChange(false)
+          break
       }
     },
-    [handleSelectResult, results, selectedIndex],
+    [results, selectedIndex, handleSelectResult, onOpenChange],
   )
+
+  const placeholder =
+    mode === 'global'
+      ? 'Search across all conversations...'
+      : 'Search in this conversation...'
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl p-0 gap-0 overflow-hidden">
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-border/50">
-          <HugeiconsIcon icon={Search01Icon} className="size-5 text-muted-foreground" />
+      <DialogContent className="w-[min(600px,92vw)] max-h-[80vh] flex flex-col overflow-hidden">
+        <div className="flex items-center gap-3 p-4 border-b border-primary-200">
+          <HugeiconsIcon
+            icon={Search01Icon}
+            size={20}
+            className="text-primary-500 shrink-0"
+          />
           <input
             ref={inputRef}
+            type="text"
             value={localQuery}
             onChange={(e) => setLocalQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={
-              mode === 'global'
-                ? 'Search all conversations...'
-                : 'Search this conversation...'
-            }
-            className="flex-1 bg-transparent outline-none text-sm placeholder:text-muted-foreground"
+            placeholder={placeholder}
+            className="flex-1 bg-transparent text-primary-900 placeholder:text-primary-400 outline-none text-base"
           />
-          {isSearching ? (
-            <HugeiconsIcon icon={Loading03Icon} className="size-5 text-muted-foreground animate-spin" />
-          ) : localQuery ? (
+          {localQuery && (
             <button
               type="button"
-              onClick={() => setLocalQuery('')}
-              className="text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => {
+                setLocalQuery('')
+                clearSearch()
+              }}
+              className="p-1 hover:bg-primary-200 rounded transition-colors"
             >
-              <HugeiconsIcon icon={Cancel01Icon} className="size-5" />
+              <HugeiconsIcon
+                icon={Cancel01Icon}
+                size={16}
+                className="text-primary-500"
+              />
             </button>
-          ) : null}
+          )}
+          {isSearching && (
+            <HugeiconsIcon
+              icon={Loading03Icon}
+              size={20}
+              className="text-primary-500 animate-spin"
+            />
+          )}
         </div>
 
-        <div ref={resultsRef} className="max-h-[60vh] overflow-y-auto p-2">
-          {localQuery.trim() && results.length === 0 && !isSearching ? (
-            <div className="px-3 py-8 text-sm text-center text-muted-foreground">
-              No results found
+        <div ref={resultsRef} className="flex-1 overflow-y-auto p-2 min-h-0">
+          {!localQuery.trim() ? (
+            <div className="text-center text-primary-500 py-8 text-sm">
+              {mode === 'global'
+                ? 'Type to search across all your conversations'
+                : 'Type to search within this conversation'}
+            </div>
+          ) : results.length === 0 && !isSearching ? (
+            <div className="text-center text-primary-500 py-8 text-sm">
+              No results found for "{localQuery}"
             </div>
           ) : (
-            results.map((result, index) => {
-              const highlighted = highlightMatch(result.messageText, localQuery)
-              return (
-                <button
-                  key={`${result.sessionKey}-${result.messageId || result.messageIndex}`}
-                  type="button"
+            <div className="flex flex-col gap-1">
+              {results.map((result, index) => (
+                <SearchResultItem
+                  key={`${result.friendlyId}-${result.messageIndex}`}
+                  result={result}
+                  query={localQuery}
+                  isSelected={index === selectedIndex}
+                  showSessionTitle={mode === 'global'}
                   onClick={() => handleSelectResult(result)}
-                  data-selected={index === selectedIndex}
-                  className={cn(
-                    'w-full text-left px-3 py-2 rounded-lg transition-colors',
-                    index === selectedIndex
-                      ? 'bg-accent text-accent-foreground'
-                      : 'hover:bg-accent/50',
-                  )}
-                >
-                  <div className="flex items-center justify-between gap-3 mb-1">
-                    <div className="text-sm font-medium truncate">{result.sessionTitle}</div>
-                    <div className="text-xs text-muted-foreground shrink-0">
-                      {result.messageRole}
-                    </div>
-                  </div>
-                  <div className="text-sm text-muted-foreground line-clamp-2 break-words">
-                    {highlighted ? (
-                      <>
-                        {highlighted.before}
-                        <mark className="bg-yellow-200/80 text-foreground rounded px-0.5">
-                          {highlighted.match}
-                        </mark>
-                        {highlighted.after}
-                      </>
-                    ) : (
-                      result.messageText
-                    )}
-                  </div>
-                </button>
-              )
-            })
+                  onMouseEnter={() => setSelectedIndex(index)}
+                />
+              ))}
+            </div>
           )}
+        </div>
+
+        <div className="flex items-center justify-between px-4 py-2 border-t border-primary-200 text-xs text-primary-500">
+          <div className="flex items-center gap-4">
+            <span className="flex items-center gap-1">
+              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">↑</kbd>
+              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">↓</kbd>
+              to navigate
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">Enter</kbd>
+              to select
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">Esc</kbd>
+              to close
+            </span>
+          </div>
+          <span>{results.length} result{results.length !== 1 ? 's' : ''}</span>
         </div>
       </DialogContent>
     </DialogRoot>
+  )
+}
+
+type SearchResultItemProps = {
+  result: SearchResult
+  query: string
+  isSelected: boolean
+  showSessionTitle: boolean
+  onClick: () => void
+  onMouseEnter: () => void
+}
+
+function SearchResultItem({
+  result,
+  query,
+  isSelected,
+  showSessionTitle,
+  onClick,
+  onMouseEnter,
+}: SearchResultItemProps) {
+  const highlight = highlightMatch(result.messageText, query)
+
+  return (
+    <button
+      type="button"
+      data-selected={isSelected}
+      className={cn(
+        'w-full text-left px-3 py-2 rounded-lg transition-colors border',
+        isSelected
+          ? 'bg-primary-100 border-primary-300'
+          : 'border-transparent hover:bg-primary-50',
+      )}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          {showSessionTitle && (
+            <div className="text-xs font-medium text-primary-600 mb-1 truncate">
+              {result.sessionTitle}
+            </div>
+          )}
+          <div className="text-sm text-primary-900 line-clamp-2 break-words">
+            {highlight ? (
+              <>
+                <span>{highlight.before}</span>
+                <mark className="bg-yellow-200 text-inherit rounded px-0.5">
+                  {highlight.match}
+                </mark>
+                <span>{highlight.after}</span>
+              </>
+            ) : (
+              result.messageText
+            )}
+          </div>
+          <div className="mt-1 text-xs text-primary-500 capitalize">
+            {result.messageRole}
+          </div>
+        </div>
+      </div>
+    </button>
   )
 }

--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -1,13 +1,14 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Search01Icon, Cancel01Icon, Loading03Icon } from '@hugeicons/core-free-icons'
 import {
-  DialogRoot,
-  DialogContent,
-} from './ui/dialog'
+  Search01Icon,
+  Cancel01Icon,
+  Loading03Icon,
+} from '@hugeicons/core-free-icons'
+import { DialogRoot, DialogContent } from './ui/dialog'
 import { useSearch, highlightMatch, type SearchResult } from '@/hooks/use-search'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
@@ -41,6 +42,7 @@ export function SearchDialog({
 
   const {
     isSearching,
+    currentResults,
     globalResults,
     searchCurrentConversation,
     searchAllSessions,
@@ -51,30 +53,31 @@ export function SearchDialog({
     currentSessionKey,
   })
 
-  // For current conversation search, compute results synchronously
-  const currentResults = useMemo(() => {
-    if (mode !== 'current') return []
-    return searchCurrentConversation(localQuery)
-  }, [mode, localQuery, searchCurrentConversation])
-
   const results = mode === 'global' ? globalResults : currentResults
 
-  // Debounced global search
   useEffect(() => {
-    if (mode !== 'global') return
     if (!localQuery.trim()) {
       clearSearch()
       return
     }
 
-    const timer = setTimeout(() => {
-      void searchAllSessions(localQuery)
+    const timer = window.setTimeout(() => {
+      if (mode === 'global') {
+        void searchAllSessions(localQuery)
+        return
+      }
+      void searchCurrentConversation(localQuery)
     }, 300)
 
-    return () => clearTimeout(timer)
-  }, [localQuery, mode, searchAllSessions, clearSearch])
+    return () => window.clearTimeout(timer)
+  }, [
+    clearSearch,
+    localQuery,
+    mode,
+    searchAllSessions,
+    searchCurrentConversation,
+  ])
 
-  // Focus input when dialog opens and cancel active search when it closes
   useEffect(() => {
     if (!open) {
       clearSearch()
@@ -84,18 +87,15 @@ export function SearchDialog({
     setLocalQuery('')
     setSelectedIndex(0)
     clearSearch()
-    // Small delay to ensure dialog is mounted
-    setTimeout(() => {
+    window.setTimeout(() => {
       inputRef.current?.focus()
     }, 50)
   }, [open, clearSearch])
 
-  // Reset selection when results change
   useEffect(() => {
     setSelectedIndex(0)
   }, [results])
 
-  // Scroll selected item into view
   useEffect(() => {
     if (!resultsRef.current) return
     const selected = resultsRef.current.querySelector('[data-selected="true"]')
@@ -107,11 +107,10 @@ export function SearchDialog({
   const handleSelectResult = useCallback(
     (result: SearchResult) => {
       onOpenChange(false)
-      
+
       if (mode === 'current' && onJumpToMessage) {
         onJumpToMessage(result)
       } else {
-        // Persist jump target so chat screen can scroll/highlight after navigation.
         if (result.messageId && typeof window !== 'undefined') {
           try {
             sessionStorage.setItem(
@@ -127,207 +126,110 @@ export function SearchDialog({
           }
         }
 
-        // Navigate to the conversation
         navigate({
           to: '/chat/$sessionKey',
           params: { sessionKey: result.friendlyId },
         })
       }
     },
-    [mode, navigate, onJumpToMessage, onOpenChange]
+    [mode, navigate, onJumpToMessage, onOpenChange],
   )
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      switch (e.key) {
-        case 'ArrowDown':
-          e.preventDefault()
-          setSelectedIndex((i) => Math.min(i + 1, results.length - 1))
-          break
-        case 'ArrowUp':
-          e.preventDefault()
-          setSelectedIndex((i) => Math.max(i - 1, 0))
-          break
-        case 'Enter':
-          e.preventDefault()
-          if (results[selectedIndex]) {
-            handleSelectResult(results[selectedIndex])
-          }
-          break
-        case 'Escape':
-          e.preventDefault()
-          onOpenChange(false)
-          break
+      if (results.length === 0) return
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelectedIndex((prev) => Math.min(prev + 1, results.length - 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelectedIndex((prev) => Math.max(prev - 1, 0))
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        const result = results[selectedIndex]
+        if (result) handleSelectResult(result)
       }
     },
-    [results, selectedIndex, handleSelectResult, onOpenChange]
+    [handleSelectResult, results, selectedIndex],
   )
-
-  const placeholder = mode === 'global' 
-    ? 'Search across all conversations...' 
-    : 'Search in this conversation...'
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(600px,92vw)] max-h-[80vh] flex flex-col overflow-hidden">
-        {/* Search input */}
-        <div className="flex items-center gap-3 p-4 border-b border-primary-200">
-          <HugeiconsIcon
-            icon={Search01Icon}
-            size={20}
-            className="text-primary-500 shrink-0"
-          />
+      <DialogContent className="max-w-2xl p-0 gap-0 overflow-hidden">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-border/50">
+          <HugeiconsIcon icon={Search01Icon} className="size-5 text-muted-foreground" />
           <input
             ref={inputRef}
-            type="text"
             value={localQuery}
             onChange={(e) => setLocalQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className="flex-1 bg-transparent text-primary-900 placeholder:text-primary-400 outline-none text-base"
+            placeholder={
+              mode === 'global'
+                ? 'Search all conversations...'
+                : 'Search this conversation...'
+            }
+            className="flex-1 bg-transparent outline-none text-sm placeholder:text-muted-foreground"
           />
-          {localQuery && (
+          {isSearching ? (
+            <HugeiconsIcon icon={Loading03Icon} className="size-5 text-muted-foreground animate-spin" />
+          ) : localQuery ? (
             <button
               type="button"
-              onClick={() => {
-                setLocalQuery('')
-                clearSearch()
-              }}
-              className="p-1 hover:bg-primary-200 rounded transition-colors"
+              onClick={() => setLocalQuery('')}
+              className="text-muted-foreground hover:text-foreground transition-colors"
             >
-              <HugeiconsIcon
-                icon={Cancel01Icon}
-                size={16}
-                className="text-primary-500"
-              />
+              <HugeiconsIcon icon={Cancel01Icon} className="size-5" />
             </button>
-          )}
-          {isSearching && (
-            <HugeiconsIcon
-              icon={Loading03Icon}
-              size={20}
-              className="text-primary-500 animate-spin"
-            />
-          )}
+          ) : null}
         </div>
 
-        {/* Results */}
-        <div
-          ref={resultsRef}
-          className="flex-1 overflow-y-auto p-2 min-h-0"
-        >
-          {!localQuery.trim() ? (
-            <div className="text-center text-primary-500 py-8 text-sm">
-              {mode === 'global' 
-                ? 'Type to search across all your conversations'
-                : 'Type to search within this conversation'}
-            </div>
-          ) : results.length === 0 && !isSearching ? (
-            <div className="text-center text-primary-500 py-8 text-sm">
-              No results found for "{localQuery}"
+        <div ref={resultsRef} className="max-h-[60vh] overflow-y-auto p-2">
+          {localQuery.trim() && results.length === 0 && !isSearching ? (
+            <div className="px-3 py-8 text-sm text-center text-muted-foreground">
+              No results found
             </div>
           ) : (
-            <div className="flex flex-col gap-1">
-              {results.map((result, index) => (
-                <SearchResultItem
-                  key={`${result.friendlyId}-${result.messageIndex}`}
-                  result={result}
-                  query={localQuery}
-                  isSelected={index === selectedIndex}
-                  showSessionTitle={mode === 'global'}
+            results.map((result, index) => {
+              const highlighted = highlightMatch(result.messageText, localQuery)
+              return (
+                <button
+                  key={`${result.sessionKey}-${result.messageId || result.messageIndex}`}
+                  type="button"
                   onClick={() => handleSelectResult(result)}
-                  onMouseEnter={() => setSelectedIndex(index)}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Footer with keyboard hints */}
-        <div className="flex items-center justify-between px-4 py-2 border-t border-primary-200 text-xs text-primary-500">
-          <div className="flex items-center gap-4">
-            <span className="flex items-center gap-1">
-              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">↑</kbd>
-              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">↓</kbd>
-              to navigate
-            </span>
-            <span className="flex items-center gap-1">
-              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">Enter</kbd>
-              to select
-            </span>
-            <span className="flex items-center gap-1">
-              <kbd className="px-1.5 py-0.5 bg-primary-100 rounded text-[10px]">Esc</kbd>
-              to close
-            </span>
-          </div>
-          {results.length > 0 && (
-            <span>{results.length} result{results.length !== 1 ? 's' : ''}</span>
+                  data-selected={index === selectedIndex}
+                  className={cn(
+                    'w-full text-left px-3 py-2 rounded-lg transition-colors',
+                    index === selectedIndex
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-accent/50',
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-3 mb-1">
+                    <div className="text-sm font-medium truncate">{result.sessionTitle}</div>
+                    <div className="text-xs text-muted-foreground shrink-0">
+                      {result.messageRole}
+                    </div>
+                  </div>
+                  <div className="text-sm text-muted-foreground line-clamp-2 break-words">
+                    {highlighted ? (
+                      <>
+                        {highlighted.before}
+                        <mark className="bg-yellow-200/80 text-foreground rounded px-0.5">
+                          {highlighted.match}
+                        </mark>
+                        {highlighted.after}
+                      </>
+                    ) : (
+                      result.messageText
+                    )}
+                  </div>
+                </button>
+              )
+            })
           )}
         </div>
       </DialogContent>
     </DialogRoot>
-  )
-}
-
-type SearchResultItemProps = {
-  result: SearchResult
-  query: string
-  isSelected: boolean
-  showSessionTitle: boolean
-  onClick: () => void
-  onMouseEnter: () => void
-}
-
-function SearchResultItem({
-  result,
-  query,
-  isSelected,
-  showSessionTitle,
-  onClick,
-  onMouseEnter,
-}: SearchResultItemProps) {
-  const highlight = highlightMatch(result.messageText, query)
-  const roleLabel = result.messageRole === 'assistant' ? 'Assistant' : 'You'
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      data-selected={isSelected}
-      className={cn(
-        'w-full text-left px-3 py-2 rounded-lg transition-colors',
-        isSelected
-          ? 'bg-primary-200'
-          : 'hover:bg-primary-100'
-      )}
-    >
-      {showSessionTitle && (
-        <div className="text-xs font-medium text-primary-600 mb-1 truncate">
-          {result.sessionTitle}
-        </div>
-      )}
-      <div className="flex items-center gap-2 mb-0.5">
-        <span
-          className={cn(
-            'text-[10px] font-medium px-1.5 py-0.5 rounded',
-            result.messageRole === 'assistant'
-              ? 'bg-blue-100 text-blue-700'
-              : 'bg-green-100 text-green-700'
-          )}
-        >
-          {roleLabel}
-        </span>
-      </div>
-      {highlight && (
-        <div className="text-sm text-primary-700 line-clamp-2">
-          <span>{highlight.before}</span>
-          <mark className="bg-yellow-200 text-primary-900 rounded px-0.5">
-            {highlight.match}
-          </mark>
-          <span>{highlight.after}</span>
-        </div>
-      )}
-    </button>
   )
 }

--- a/src/hooks/use-search.ts
+++ b/src/hooks/use-search.ts
@@ -9,7 +9,7 @@ import { chatQueryKeys, fetchHistory } from '@/screens/chat/chat-queries'
 
 const SEARCH_PAGE_SIZE = 200
 const GLOBAL_SEARCH_THRESHOLD = 200
-const MAX_HISTORY_FETCH_ITERATIONS = 20
+const MAX_HISTORY_PAGES = 20
 
 export type SearchResult = {
   sessionKey: string
@@ -329,7 +329,10 @@ async function getSearchableHistory({
     : await fetchHistory({
         sessionKey,
         friendlyId,
-        limit: Math.max(minMessages ?? GLOBAL_SEARCH_THRESHOLD, GLOBAL_SEARCH_THRESHOLD),
+        limit: Math.max(
+          minMessages ?? GLOBAL_SEARCH_THRESHOLD,
+          GLOBAL_SEARCH_THRESHOLD,
+        ),
       })
 
   if (signal.aborted) {
@@ -352,26 +355,24 @@ async function getSearchableHistory({
   return nextData
 }
 
-function hasSufficientCachedHistory(
+export export function hasSufficientCachedHistory(
   cachedServerMessages: Array<GatewayMessage>,
   cachedHasMore: boolean,
   fetchAll: boolean,
   minMessages?: number,
 ): boolean {
   if (cachedServerMessages.length === 0) return false
+  const threshold = minMessages ?? GLOBAL_SEARCH_THRESHOLD
   if (fetchAll) {
-    return (
-      !cachedHasMore &&
-      cachedServerMessages.length >= GLOBAL_SEARCH_THRESHOLD
-    )
+    return !cachedHasMore && cachedServerMessages.length >= threshold
   }
-  if (cachedServerMessages.length >= (minMessages ?? GLOBAL_SEARCH_THRESHOLD)) {
+  if (cachedServerMessages.length >= threshold) {
     return true
   }
   return !cachedHasMore
 }
 
-async function fetchEntireHistory({
+export export async function fetchEntireHistory({
   friendlyId,
   sessionKey,
   signal,
@@ -388,7 +389,8 @@ async function fetchEntireHistory({
   let iterations = 0
 
   do {
-    iterations += 1
+    const previousLength = accumulated.length
+    const previousBefore = before
     const page = await fetchHistory({
       sessionKey,
       friendlyId,
@@ -402,14 +404,21 @@ async function fetchEntireHistory({
 
     responseSessionKey = page.sessionKey || responseSessionKey
     sessionId = page.sessionId ?? sessionId
-    const previousCount = accumulated.length
     accumulated = dedupeMessages(page.messages, accumulated)
     hasMore = page.hasMore ?? false
-    if (accumulated.length === previousCount || iterations >= MAX_HISTORY_FETCH_ITERATIONS) {
+    before = getOldestHistoryCursor(accumulated)
+    iterations += 1
+
+    const didGrow = accumulated.length > previousLength
+    const cursorStalled =
+      typeof previousBefore === 'string' &&
+      previousBefore.length > 0 &&
+      previousBefore === before
+
+    if (!didGrow || cursorStalled || iterations >= MAX_HISTORY_PAGES) {
       hasMore = false
       break
     }
-    before = getOldestHistoryCursor(accumulated)
   } while (hasMore && before)
 
   return {
@@ -494,10 +503,6 @@ function messageIdentity(message: GatewayMessage): string {
   ].join('|')
 }
 
-/**
- * Highlights matched text in search results.
- * Returns the matched portion with surrounding context, or null if no match.
- */
 export function highlightMatch(
   text: string,
   query: string,

--- a/src/hooks/use-search.ts
+++ b/src/hooks/use-search.ts
@@ -355,7 +355,7 @@ async function getSearchableHistory({
   return nextData
 }
 
-export export function hasSufficientCachedHistory(
+export function hasSufficientCachedHistory(
   cachedServerMessages: Array<GatewayMessage>,
   cachedHasMore: boolean,
   fetchAll: boolean,
@@ -364,7 +364,10 @@ export export function hasSufficientCachedHistory(
   if (cachedServerMessages.length === 0) return false
   const threshold = minMessages ?? GLOBAL_SEARCH_THRESHOLD
   if (fetchAll) {
-    return !cachedHasMore && cachedServerMessages.length >= threshold
+    // If we know there's no more history (hasMore=false), the cache is complete regardless of size
+    if (!cachedHasMore) return true
+    // Otherwise need enough messages to be confident
+    return cachedServerMessages.length >= threshold
   }
   if (cachedServerMessages.length >= threshold) {
     return true
@@ -372,7 +375,7 @@ export export function hasSufficientCachedHistory(
   return !cachedHasMore
 }
 
-export export async function fetchEntireHistory({
+export async function fetchEntireHistory({
   friendlyId,
   sessionKey,
   signal,
@@ -396,6 +399,7 @@ export export async function fetchEntireHistory({
       friendlyId,
       limit: SEARCH_PAGE_SIZE,
       before,
+      signal,
     })
 
     if (signal.aborted) {

--- a/src/hooks/use-search.ts
+++ b/src/hooks/use-search.ts
@@ -1,7 +1,15 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
-import type { SessionMeta, GatewayMessage, HistoryResponse } from '@/screens/chat/types'
-import { chatQueryKeys } from '@/screens/chat/chat-queries'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
+import type {
+  SessionMeta,
+  GatewayMessage,
+  HistoryResponse,
+} from '@/screens/chat/types'
+import { chatQueryKeys, fetchHistory } from '@/screens/chat/chat-queries'
+
+const SEARCH_PAGE_SIZE = 200
+const GLOBAL_SEARCH_THRESHOLD = 200
+const MAX_HISTORY_FETCH_ITERATIONS = 20
 
 export type SearchResult = {
   sessionKey: string
@@ -24,7 +32,7 @@ type UseSearchOptions = {
 
 function extractTextFromContent(content: unknown): string {
   if (!Array.isArray(content)) return ''
-  
+
   return content
     .map((item) => {
       if (item?.type === 'text' && typeof item.text === 'string') {
@@ -37,80 +45,100 @@ function extractTextFromContent(content: unknown): string {
 }
 
 function extractTextFromMessage(message: GatewayMessage): string {
-  // Try content array first
   const contentText = extractTextFromContent(message.content)
   if (contentText) return contentText
-  
-  // Fall back to direct text field if present
+
   if (typeof (message as any).text === 'string') {
     return (message as any).text
   }
-  
+
   return ''
 }
 
-export function useSearch({ sessions, currentFriendlyId, currentSessionKey }: UseSearchOptions) {
+export function useSearch({
+  sessions,
+  currentFriendlyId,
+  currentSessionKey,
+}: UseSearchOptions) {
   const queryClient = useQueryClient()
   const [query, setQuery] = useState('')
   const [isSearching, setIsSearching] = useState(false)
+  const [currentResults, setCurrentResults] = useState<SearchResult[]>([])
   const [globalResults, setGlobalResults] = useState<SearchResult[]>([])
+  const currentSearchControllerRef = useRef<AbortController | null>(null)
   const globalSearchControllerRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     return () => {
+      currentSearchControllerRef.current?.abort()
+      currentSearchControllerRef.current = null
       globalSearchControllerRef.current?.abort()
       globalSearchControllerRef.current = null
     }
   }, [])
 
-  // Search within current conversation (uses cached history)
   const searchCurrentConversation = useCallback(
-    (searchQuery: string): SearchResult[] => {
-      if (!searchQuery.trim() || !currentFriendlyId || !currentSessionKey) {
+    async (searchQuery: string): Promise<SearchResult[]> => {
+      const trimmedQuery = searchQuery.trim()
+      if (!trimmedQuery || !currentFriendlyId || !currentSessionKey) {
+        currentSearchControllerRef.current?.abort()
+        currentSearchControllerRef.current = null
+        setCurrentResults([])
         return []
       }
 
-      const historyKey = chatQueryKeys.history(currentFriendlyId, currentSessionKey)
-      const historyData = queryClient.getQueryData(historyKey) as HistoryResponse | undefined
-      
-      if (!historyData?.messages) return []
+      currentSearchControllerRef.current?.abort()
+      const controller = new AbortController()
+      currentSearchControllerRef.current = controller
 
-      const normalizedQuery = searchQuery.toLowerCase()
-      const results: SearchResult[] = []
-      
-      const session = sessions.find(s => s.friendlyId === currentFriendlyId)
-      const sessionTitle = session?.label || session?.title || session?.derivedTitle || currentFriendlyId
+      setIsSearching(true)
+      setCurrentResults([])
 
-      historyData.messages.forEach((message, index) => {
-        const text = extractTextFromMessage(message)
-        if (!text) return
+      try {
+        const session = sessions.find((item) => item.friendlyId === currentFriendlyId)
+        const sessionTitle =
+          session?.label ||
+          session?.title ||
+          session?.derivedTitle ||
+          currentFriendlyId
 
-        const lowerText = text.toLowerCase()
-        const matchIndex = lowerText.indexOf(normalizedQuery)
-        
-        if (matchIndex !== -1) {
-          results.push({
-            sessionKey: currentSessionKey,
-            friendlyId: currentFriendlyId,
-            sessionTitle,
-            messageIndex: index,
-            messageId: typeof message.id === 'string' ? message.id : undefined,
-            messageRole: message.role || 'unknown',
-            messageText: text,
-            matchStart: matchIndex,
-            matchEnd: matchIndex + searchQuery.length,
-            timestamp: message.timestamp,
-          })
+        const historyData = await getSearchableHistory({
+          friendlyId: currentFriendlyId,
+          queryClient,
+          sessionKey: currentSessionKey,
+          signal: controller.signal,
+          fetchAll: true,
+        })
+
+        const results = createSearchResults({
+          messages: historyData.messages,
+          normalizedQuery: trimmedQuery.toLowerCase(),
+          searchQuery: trimmedQuery,
+          sessionKey: currentSessionKey,
+          friendlyId: currentFriendlyId,
+          sessionTitle,
+        })
+
+        if (currentSearchControllerRef.current === controller) {
+          setCurrentResults(results)
         }
-      })
 
-      return results
+        return results
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return []
+        }
+        throw error
+      } finally {
+        if (currentSearchControllerRef.current === controller) {
+          currentSearchControllerRef.current = null
+          setIsSearching(false)
+        }
+      }
     },
-    [currentFriendlyId, currentSessionKey, queryClient, sessions]
+    [currentFriendlyId, currentSessionKey, queryClient, sessions],
   )
 
-  // Search across all sessions (fetches history for each).
-  // NOTE: This function is called imperatively; caller should debounce input events.
   const searchAllSessions = useCallback(
     async (searchQuery: string): Promise<SearchResult[]> => {
       const trimmedQuery = searchQuery.trim()
@@ -121,7 +149,6 @@ export function useSearch({ sessions, currentFriendlyId, currentSessionKey }: Us
         return []
       }
 
-      // Cancel any in-flight global search before starting a new one.
       globalSearchControllerRef.current?.abort()
       const controller = new AbortController()
       globalSearchControllerRef.current = controller
@@ -131,91 +158,58 @@ export function useSearch({ sessions, currentFriendlyId, currentSessionKey }: Us
 
       const normalizedQuery = trimmedQuery.toLowerCase()
       const allResults: SearchResult[] = []
-      const BATCH_SIZE = 10
+      const batchSize = 10
 
       try {
-        for (let i = 0; i < sessions.length; i += BATCH_SIZE) {
+        for (let index = 0; index < sessions.length; index += batchSize) {
           if (controller.signal.aborted) {
             throw new DOMException('Search aborted', 'AbortError')
           }
 
-          const batch = sessions.slice(i, i + BATCH_SIZE)
-
-          // Use Promise.allSettled for better error resilience - failed sessions don't block others
+          const batch = sessions.slice(index, index + batchSize)
           const batchSettled = await Promise.allSettled(
             batch.map(async (session) => {
-              // Try to get from cache first
-              const historyKey = chatQueryKeys.history(session.friendlyId, session.key)
-              let historyData = queryClient.getQueryData(historyKey) as HistoryResponse | undefined
-
-              // If not cached, fetch it
-              if (!historyData) {
-                const params = new URLSearchParams({
-                  sessionKey: session.key,
-                  friendlyId: session.friendlyId,
-                  limit: '200',
-                })
-                const res = await fetch(`/api/history?${params.toString()}`, {
-                  signal: controller.signal,
-                })
-                if (res.ok) {
-                  historyData = await res.json() as HistoryResponse
-                  // Cache it for later
-                  queryClient.setQueryData(historyKey, historyData)
-                }
-              }
-
-              if (!historyData?.messages) return [] as SearchResult[]
-
-              const sessionTitle = session.label || session.title || session.derivedTitle || session.friendlyId
-              const sessionResults: SearchResult[] = []
-
-              historyData.messages.forEach((message, index) => {
-                const text = extractTextFromMessage(message)
-                if (!text) return
-
-                const lowerText = text.toLowerCase()
-                const matchIndex = lowerText.indexOf(normalizedQuery)
-
-                if (matchIndex !== -1) {
-                  sessionResults.push({
-                    sessionKey: session.key,
-                    friendlyId: session.friendlyId,
-                    sessionTitle,
-                    messageIndex: index,
-                    messageId: typeof message.id === 'string' ? message.id : undefined,
-                    messageRole: message.role || 'unknown',
-                    messageText: text,
-                    matchStart: matchIndex,
-                    matchEnd: matchIndex + trimmedQuery.length,
-                    timestamp: message.timestamp,
-                  })
-                }
+              const historyData = await getSearchableHistory({
+                friendlyId: session.friendlyId,
+                minMessages: GLOBAL_SEARCH_THRESHOLD,
+                queryClient,
+                sessionKey: session.key,
+                signal: controller.signal,
               })
 
-              return sessionResults
-            })
+              const sessionTitle =
+                session.label ||
+                session.title ||
+                session.derivedTitle ||
+                session.friendlyId
+
+              return createSearchResults({
+                messages: historyData.messages,
+                normalizedQuery,
+                searchQuery: trimmedQuery,
+                sessionKey: session.key,
+                friendlyId: session.friendlyId,
+                sessionTitle,
+              })
+            }),
           )
 
-          // Extract successful results, skip failures silently
           for (const result of batchSettled) {
             if (result.status === 'fulfilled') {
               allResults.push(...result.value)
             }
-            // Rejected promises are silently skipped (network errors, etc.)
           }
 
-          // Progressive updates after each batch.
           allResults.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
           setGlobalResults([...allResults])
         }
 
         return allResults
       } catch (error) {
-        if (!(error instanceof DOMException && error.name === 'AbortError')) {
-          throw error
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return []
         }
-        return []
+        throw error
       } finally {
         if (globalSearchControllerRef.current === controller) {
           globalSearchControllerRef.current = null
@@ -223,14 +217,17 @@ export function useSearch({ sessions, currentFriendlyId, currentSessionKey }: Us
         }
       }
     },
-    [sessions, queryClient]
+    [sessions, queryClient],
   )
 
   const clearSearch = useCallback(() => {
+    currentSearchControllerRef.current?.abort()
+    currentSearchControllerRef.current = null
     globalSearchControllerRef.current?.abort()
     globalSearchControllerRef.current = null
     setIsSearching(false)
     setQuery('')
+    setCurrentResults([])
     setGlobalResults([])
   }, [])
 
@@ -238,11 +235,263 @@ export function useSearch({ sessions, currentFriendlyId, currentSessionKey }: Us
     query,
     setQuery,
     isSearching,
+    currentResults,
     globalResults,
     searchCurrentConversation,
     searchAllSessions,
     clearSearch,
   }
+}
+
+function createSearchResults({
+  messages,
+  normalizedQuery,
+  searchQuery,
+  sessionKey,
+  friendlyId,
+  sessionTitle,
+}: {
+  messages: Array<GatewayMessage>
+  normalizedQuery: string
+  searchQuery: string
+  sessionKey: string
+  friendlyId: string
+  sessionTitle: string
+}): SearchResult[] {
+  const results: SearchResult[] = []
+
+  messages.forEach((message, index) => {
+    const text = extractTextFromMessage(message)
+    if (!text) return
+
+    const lowerText = text.toLowerCase()
+    const matchIndex = lowerText.indexOf(normalizedQuery)
+    if (matchIndex === -1) return
+
+    results.push({
+      sessionKey,
+      friendlyId,
+      sessionTitle,
+      messageIndex: index,
+      messageId: typeof message.id === 'string' ? message.id : undefined,
+      messageRole: message.role || 'unknown',
+      messageText: text,
+      matchStart: matchIndex,
+      matchEnd: matchIndex + searchQuery.length,
+      timestamp: message.timestamp,
+    })
+  })
+
+  return results
+}
+
+async function getSearchableHistory({
+  friendlyId,
+  minMessages,
+  queryClient,
+  sessionKey,
+  signal,
+  fetchAll = false,
+}: {
+  friendlyId: string
+  minMessages?: number
+  queryClient: QueryClient
+  sessionKey: string
+  signal: AbortSignal
+  fetchAll?: boolean
+}): Promise<HistoryResponse> {
+  const historyKey = chatQueryKeys.history(friendlyId, sessionKey)
+  const cached = queryClient.getQueryData(historyKey) as HistoryResponse | undefined
+  const optimisticMessages = getOptimisticMessages(cached?.messages)
+  const cachedServerMessages = getServerMessages(cached?.messages)
+  const cachedHasMore = cached?.hasMore ?? false
+
+  if (
+    hasSufficientCachedHistory(
+      cachedServerMessages,
+      cachedHasMore,
+      fetchAll,
+      minMessages,
+    )
+  ) {
+    return {
+      sessionKey: cached?.sessionKey || sessionKey,
+      sessionId: cached?.sessionId,
+      messages: optimisticMessages.length
+        ? mergeOptimisticHistoryMessages(cachedServerMessages, optimisticMessages)
+        : cachedServerMessages,
+      hasMore: cachedHasMore,
+    }
+  }
+
+  const fetched = fetchAll
+    ? await fetchEntireHistory({ friendlyId, sessionKey, signal })
+    : await fetchHistory({
+        sessionKey,
+        friendlyId,
+        limit: Math.max(minMessages ?? GLOBAL_SEARCH_THRESHOLD, GLOBAL_SEARCH_THRESHOLD),
+      })
+
+  if (signal.aborted) {
+    throw new DOMException('Search aborted', 'AbortError')
+  }
+
+  const mergedMessages = optimisticMessages.length
+    ? mergeOptimisticHistoryMessages(fetched.messages, optimisticMessages)
+    : fetched.messages
+
+  const nextData = {
+    sessionKey: fetched.sessionKey || cached?.sessionKey || sessionKey,
+    sessionId: fetched.sessionId ?? cached?.sessionId,
+    messages: mergedMessages,
+    hasMore: fetched.hasMore ?? false,
+  } satisfies HistoryResponse
+
+  queryClient.setQueryData(historyKey, nextData)
+
+  return nextData
+}
+
+function hasSufficientCachedHistory(
+  cachedServerMessages: Array<GatewayMessage>,
+  cachedHasMore: boolean,
+  fetchAll: boolean,
+  minMessages?: number,
+): boolean {
+  if (cachedServerMessages.length === 0) return false
+  if (fetchAll) {
+    return (
+      !cachedHasMore &&
+      cachedServerMessages.length >= GLOBAL_SEARCH_THRESHOLD
+    )
+  }
+  if (cachedServerMessages.length >= (minMessages ?? GLOBAL_SEARCH_THRESHOLD)) {
+    return true
+  }
+  return !cachedHasMore
+}
+
+async function fetchEntireHistory({
+  friendlyId,
+  sessionKey,
+  signal,
+}: {
+  friendlyId: string
+  sessionKey: string
+  signal: AbortSignal
+}): Promise<HistoryResponse> {
+  let accumulated: Array<GatewayMessage> = []
+  let sessionId: string | undefined
+  let responseSessionKey = sessionKey
+  let before: string | undefined
+  let hasMore = false
+  let iterations = 0
+
+  do {
+    iterations += 1
+    const page = await fetchHistory({
+      sessionKey,
+      friendlyId,
+      limit: SEARCH_PAGE_SIZE,
+      before,
+    })
+
+    if (signal.aborted) {
+      throw new DOMException('Search aborted', 'AbortError')
+    }
+
+    responseSessionKey = page.sessionKey || responseSessionKey
+    sessionId = page.sessionId ?? sessionId
+    const previousCount = accumulated.length
+    accumulated = dedupeMessages(page.messages, accumulated)
+    hasMore = page.hasMore ?? false
+    if (accumulated.length === previousCount || iterations >= MAX_HISTORY_FETCH_ITERATIONS) {
+      hasMore = false
+      break
+    }
+    before = getOldestHistoryCursor(accumulated)
+  } while (hasMore && before)
+
+  return {
+    sessionKey: responseSessionKey,
+    sessionId,
+    messages: accumulated,
+    hasMore,
+  }
+}
+
+function getOptimisticMessages(
+  messages: Array<GatewayMessage> | undefined,
+): Array<GatewayMessage> {
+  if (!Array.isArray(messages)) return []
+  return messages.filter((message) => isOptimisticMessage(message))
+}
+
+function getServerMessages(
+  messages: Array<GatewayMessage> | undefined,
+): Array<GatewayMessage> {
+  if (!Array.isArray(messages)) return []
+  return messages.filter((message) => !isOptimisticMessage(message))
+}
+
+function isOptimisticMessage(message: GatewayMessage): boolean {
+  if (message.status === 'sending') return true
+  if (message.__optimisticId) return true
+  return Boolean(message.clientId)
+}
+
+function mergeOptimisticHistoryMessages(
+  serverMessages: Array<GatewayMessage>,
+  optimisticMessages: Array<GatewayMessage>,
+): Array<GatewayMessage> {
+  return dedupeMessages(serverMessages, optimisticMessages)
+}
+
+function getOldestHistoryCursor(
+  messages: Array<GatewayMessage>,
+): string | undefined {
+  const oldestMessage = messages.find((message) => !isOptimisticMessage(message))
+  if (!oldestMessage) return undefined
+  if (typeof oldestMessage.id === 'string' && oldestMessage.id.trim().length > 0) {
+    return oldestMessage.id.trim()
+  }
+  return undefined
+}
+
+function dedupeMessages(...chunks: Array<Array<GatewayMessage>>): Array<GatewayMessage> {
+  const merged: Array<GatewayMessage> = []
+  const seen = new Set<string>()
+
+  for (const chunk of chunks) {
+    for (const message of chunk) {
+      const key = messageIdentity(message)
+      if (seen.has(key)) continue
+      seen.add(key)
+      merged.push(message)
+    }
+  }
+
+  return merged
+}
+
+function messageIdentity(message: GatewayMessage): string {
+  if (typeof message.id === 'string' && message.id.length > 0) {
+    return `id:${message.id}`
+  }
+  if (typeof message.clientId === 'string' && message.clientId.length > 0) {
+    return `client:${message.clientId}`
+  }
+  if (
+    typeof message.__optimisticId === 'string' &&
+    message.__optimisticId.length > 0
+  ) {
+    return `optimistic:${message.__optimisticId}`
+  }
+  return [
+    message.role ?? '',
+    message.timestamp ?? '',
+    extractTextFromMessage(message),
+  ].join('|')
 }
 
 /**
@@ -261,21 +510,19 @@ export function highlightMatch(
 
   if (matchIndex === -1) return null
 
-  // Calculate context around the match
   const contextBefore = 40
   const contextAfter = 80
-  
+
   let start = Math.max(0, matchIndex - contextBefore)
   let end = Math.min(text.length, matchIndex + query.length + contextAfter)
 
-  // Adjust to word boundaries if possible
   if (start > 0) {
     const spaceIndex = text.indexOf(' ', start)
     if (spaceIndex !== -1 && spaceIndex < matchIndex) {
       start = spaceIndex + 1
     }
   }
-  
+
   if (end < text.length) {
     const spaceIndex = text.lastIndexOf(' ', end)
     if (spaceIndex > matchIndex + query.length) {
@@ -285,7 +532,9 @@ export function highlightMatch(
 
   const before = (start > 0 ? '...' : '') + text.slice(start, matchIndex)
   const match = text.slice(matchIndex, matchIndex + query.length)
-  const after = text.slice(matchIndex + query.length, end) + (end < text.length ? '...' : '')
+  const after =
+    text.slice(matchIndex + query.length, end) +
+    (end < text.length ? '...' : '')
 
   return { before, match, after }
 }

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -7,6 +7,7 @@ type ChatHistoryResponse = {
   sessionId?: string
   messages: Array<any>
   thinkingLevel?: string
+  hasMore?: boolean
 }
 
 type SessionsResolveResponse = {
@@ -20,9 +21,10 @@ export const Route = createFileRoute('/api/history')({
       GET: async ({ request }) => {
         try {
           const url = new URL(request.url)
-          const limit = Number(url.searchParams.get('limit') || '200')
+          const limit = Number(url.searchParams.get('limit') || '50')
           const rawSessionKey = url.searchParams.get('sessionKey')?.trim()
           const friendlyId = url.searchParams.get('friendlyId')?.trim()
+          const before = url.searchParams.get('before')?.trim() || undefined
 
           let sessionKey =
             rawSessionKey && rawSessionKey.length > 0 ? rawSessionKey : ''
@@ -48,15 +50,19 @@ export const Route = createFileRoute('/api/history')({
             sessionKey = 'main'
           }
 
+          const params: Record<string, unknown> = { sessionKey, limit }
+          if (before) params.before = before
+
           const payload = await gatewayRpc<ChatHistoryResponse>(
             'chat.history',
-            {
-              sessionKey,
-              limit,
-            },
+            params,
           )
 
-          return json(payload)
+          // Infer hasMore: if the gateway returned exactly `limit` messages,
+          // there are likely more. The gateway may also set hasMore explicitly.
+          const hasMore = payload.hasMore ?? payload.messages.length >= limit
+
+          return json({ ...payload, hasMore })
         } catch (err) {
           return json(
             {

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -5,7 +5,7 @@ import { gatewayRpc } from '../../server/gateway'
 type ChatHistoryResponse = {
   sessionKey: string
   sessionId?: string
-  messages: Array<any>
+  messages: Array<unknown>
   thinkingLevel?: string
   hasMore?: boolean
 }
@@ -21,7 +21,11 @@ export const Route = createFileRoute('/api/history')({
       GET: async ({ request }) => {
         try {
           const url = new URL(request.url)
-          const limit = Number(url.searchParams.get('limit') || '50')
+          const rawLimit = Number(url.searchParams.get('limit') || '50')
+          const limit =
+            Number.isFinite(rawLimit) && rawLimit > 0
+              ? Math.min(Math.trunc(rawLimit), 200)
+              : 50
           const rawSessionKey = url.searchParams.get('sessionKey')?.trim()
           const friendlyId = url.searchParams.get('friendlyId')?.trim()
           const before = url.searchParams.get('before')?.trim() || undefined
@@ -50,7 +54,12 @@ export const Route = createFileRoute('/api/history')({
             sessionKey = 'main'
           }
 
-          const params: Record<string, unknown> = { sessionKey, limit }
+          // Ask the gateway for one extra message so hasMore can be inferred
+          // without the exact-limit false positive.
+          const params: Record<string, unknown> = {
+            sessionKey,
+            limit: limit + 1,
+          }
           if (before) params.before = before
 
           const payload = await gatewayRpc<ChatHistoryResponse>(
@@ -58,11 +67,14 @@ export const Route = createFileRoute('/api/history')({
             params,
           )
 
-          // Infer hasMore: if the gateway returned exactly `limit` messages,
-          // there are likely more. The gateway may also set hasMore explicitly.
-          const hasMore = payload.hasMore ?? payload.messages.length >= limit
+          const messages = Array.isArray(payload.messages)
+            ? payload.messages.slice(-limit)
+            : []
+          const hasMore =
+            payload.hasMore ??
+            (Array.isArray(payload.messages) && payload.messages.length > limit)
 
-          return json({ ...payload, hasMore })
+          return json({ ...payload, messages, hasMore })
         } catch (err) {
           return json(
             {

--- a/src/screens/chat/chat-queries.ts
+++ b/src/screens/chat/chat-queries.ts
@@ -29,10 +29,13 @@ export async function fetchSessions(): Promise<Array<SessionMeta>> {
 export async function fetchHistory(payload: {
   sessionKey: string
   friendlyId: string
+  limit?: number
+  before?: string
 }): Promise<HistoryResponse> {
-  const query = new URLSearchParams({ limit: '200' })
+  const query = new URLSearchParams({ limit: String(payload.limit ?? 50) })
   if (payload.sessionKey) query.set('sessionKey', payload.sessionKey)
   if (payload.friendlyId) query.set('friendlyId', payload.friendlyId)
+  if (payload.before) query.set('before', payload.before)
   const res = await fetch(`/api/history?${query.toString()}`)
   if (!res.ok) throw new Error(await readError(res))
   return (await res.json()) as HistoryResponse

--- a/src/screens/chat/chat-queries.ts
+++ b/src/screens/chat/chat-queries.ts
@@ -31,12 +31,15 @@ export async function fetchHistory(payload: {
   friendlyId: string
   limit?: number
   before?: string
+  signal?: AbortSignal
 }): Promise<HistoryResponse> {
   const query = new URLSearchParams({ limit: String(payload.limit ?? 50) })
   if (payload.sessionKey) query.set('sessionKey', payload.sessionKey)
   if (payload.friendlyId) query.set('friendlyId', payload.friendlyId)
   if (payload.before) query.set('before', payload.before)
-  const res = await fetch(`/api/history?${query.toString()}`)
+  const res = await fetch(`/api/history?${query.toString()}`, {
+    signal: payload.signal,
+  })
   if (!res.ok) throw new Error(await readError(res))
   return (await res.json()) as HistoryResponse
 }

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1303,7 +1303,7 @@ export function ChatScreen({
             onOpenChange={setShowSearchDialog}
             sessions={sessions}
             currentFriendlyId={activeFriendlyId}
-            currentSessionKey={activeSessionKey}
+            currentSessionKey={resolvedSessionKey || activeSessionKey}
             mode={searchMode}
             onJumpToMessage={(result: SearchResult) => {
               setShowSearchDialog(false)

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -180,6 +180,9 @@ export function ChatScreen({
     resolvedSessionKey,
     activeCanonicalKey,
     sessionKeyForHistory,
+    hasMore,
+    isLoadingMore,
+    loadMore,
   } = useChatHistory({
     activeFriendlyId,
     activeSessionKey,
@@ -1269,6 +1272,9 @@ export function ChatScreen({
                 jumpToMessageId={searchJumpMessageId}
                 onRetryMessage={handleRetryMessage}
                 onDismissMessage={handleDismissMessage}
+                hasMore={hasMore}
+                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMore}
               />
               <ChatComposer
                 onSubmit={send}

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1273,8 +1273,8 @@ export function ChatScreen({
                 onRetryMessage={handleRetryMessage}
                 onDismissMessage={handleDismissMessage}
                 hasMore={hasMore}
-                isLoadingMore={isLoadingMore}
                 onLoadMore={loadMore}
+                isLoadingMore={isLoadingMore}
               />
               <ChatComposer
                 onSubmit={send}

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -35,26 +35,18 @@ type ChatMessageListProps = {
   notice?: React.ReactNode
   noticePosition?: 'start' | 'end'
   waitingForResponse: boolean
-  /** True while the assistant response is actively being streamed / fast-polled */
   isStreaming?: boolean
   sessionKey?: string
   pinToTop: boolean
   pinGroupMinHeight: number
   headerHeight: number
   contentStyle?: React.CSSProperties
-  /** Callback when a follow-up suggestion is clicked */
   onFollowUpClick?: (suggestion: string) => void
-  /** Message id to scroll to and briefly highlight */
   jumpToMessageId?: string | null
-  /** Called when user clicks Retry on a failed message */
   onRetryMessage?: (message: GatewayMessage) => void
-  /** Called when user clicks Dismiss on a failed message */
   onDismissMessage?: (message: GatewayMessage) => void
-  /** Whether there are earlier messages to load */
   hasMore?: boolean
-  /** Called when user wants to load earlier messages */
   onLoadMore?: () => void
-  /** True while an earlier history page is being fetched */
   isLoadingMore?: boolean
 }
 
@@ -85,18 +77,31 @@ function ChatMessageListComponent({
   const programmaticScroll = useRef(false)
   const prevPinRef = useRef(pinToTop)
   const prevUserIndexRef = useRef<number | undefined>(undefined)
-  const prevFirstMessageIdRef = useRef<string | undefined>(undefined)
-  const loadMoreRequestRef = useRef(false)
+  const prevDisplayLengthRef = useRef(0)
+  const prevFirstMessageKeyRef = useRef<string | null>(null)
+  const prevLastMessageKeyRef = useRef<string | null>(null)
+  const restoreScrollMessageIdRef = useRef<string | null>(null)
+  const pendingScrollRestoreRef = useRef<{
+    scrollHeight: number
+    scrollTop: number
+  } | null>(null)
   const [highlightedMessageId, setHighlightedMessageId] = useState<
     string | null
   >(null)
 
-  // Filter out toolResult messages - they'll be displayed inside their associated tool calls
   const displayMessages = useMemo(() => {
     return messages.filter((msg) => msg.role !== 'toolResult')
   }, [messages])
 
   const deferredDisplayMessages = useDeferredValue(displayMessages)
+
+  const updateDisplaySnapshot = useCallback(() => {
+    prevDisplayLengthRef.current = displayMessages.length
+    prevFirstMessageKeyRef.current = getMessageStableKey(displayMessages[0])
+    prevLastMessageKeyRef.current = getMessageStableKey(
+      displayMessages[displayMessages.length - 1],
+    )
+  }, [displayMessages])
 
   const toolResultsByCallId = useMemo(() => {
     const map = new Map<string, GatewayMessage>()
@@ -143,11 +148,7 @@ function ChatMessageListComponent({
     return parts.join('||')
   }, [deferredDisplayMessages, deferredToolResultsByCallId])
 
-  // Aggregate all search sources across assistant tool outputs for the badge.
-  // Using deferred inputs + a narrow signature avoids reparsing the same JSON
-  // during rapid polling / StrictMode churn.
   const aggregatedSearchSources = useMemo(() => {
-    // Strip Gateway security tags from search result text
     const strip = (s: string) => {
       if (!s) return ''
       return s
@@ -161,7 +162,6 @@ function ChatMessageListComponent({
         .replace(/\n{2,}/g, '\n')
         .trim()
     }
-    // Try to extract search results from any JSON text
     const extractResults = (
       text: string,
       sources: SearchSource[],
@@ -169,8 +169,6 @@ function ChatMessageListComponent({
     ) => {
       try {
         const parsed = JSON.parse(text)
-        // Handle web-search-plus format: { provider, query, results: [...] }
-        // Handle web_search format: { results: [...] } or direct array
         const items = Array.isArray(parsed)
           ? parsed
           : (parsed?.results ?? parsed?.web?.results ?? [])
@@ -213,13 +211,9 @@ function ChatMessageListComponent({
           .trim()
         if (!text) continue
         if (isSearch || isExec) {
-          // For exec: only extract if the output looks like search JSON
-          // (has "results" array with url+title objects)
           if (isExec) {
-            // Quick check: must contain "results" and "url" to be search output
             if (!text.includes('"results"') || !text.includes('"url"')) continue
           }
-          // Try to find JSON in the text (exec output may have extra text before/after)
           let jsonText = text
           const jsonStart = text.indexOf('{')
           if (jsonStart > 0) jsonText = text.slice(jsonStart)
@@ -268,11 +262,9 @@ function ChatMessageListComponent({
     (typeof lastUserIndex !== 'number' ||
       typeof lastAssistantIndex !== 'number' ||
       lastAssistantIndex < lastUserIndex)
-  // Pin the last user+assistant group without adding bottom padding.
   const groupStartIndex = typeof lastUserIndex === 'number' ? lastUserIndex : -1
   const hasGroup = pinToTop && groupStartIndex >= 0
 
-  // Get the last assistant message text for follow-up suggestions
   const lastAssistantMessage =
     typeof lastTextAssistantIndex === 'number'
       ? displayMessages[lastTextAssistantIndex]
@@ -280,10 +272,6 @@ function ChatMessageListComponent({
   const lastAssistantText = lastAssistantMessage
     ? textFromMessage(lastAssistantMessage)
     : ''
-  // Show follow-ups only when:
-  // - Not waiting for response
-  // - There's a last assistant message
-  // - The last message in conversation is from assistant (not user waiting for response)
   const showFollowUps =
     !waitingForResponse &&
     !isStreaming &&
@@ -293,25 +281,31 @@ function ChatMessageListComponent({
       typeof lastTextAssistantIndex !== 'number' ||
       lastTextAssistantIndex > lastUserIndex)
 
-  const firstDisplayMessageId = displayMessages.find(
-    (message) => typeof message.id === 'string' && message.id.length > 0,
-  )?.id
-
   const handleLoadMoreClick = useCallback(() => {
     if (!onLoadMore || isLoadingMore) return
-    loadMoreRequestRef.current = true
+    const firstVisibleMessage = displayMessages.find(
+      (message) => typeof message.id === 'string' && message.id.length > 0,
+    )
+    restoreScrollMessageIdRef.current = firstVisibleMessage?.id ?? null
     onLoadMore()
-  }, [isLoadingMore, onLoadMore])
+  }, [displayMessages, isLoadingMore, onLoadMore])
 
   useLayoutEffect(() => {
     if (loading) return
 
-    const completedLoadMore = loadMoreRequestRef.current && !isLoadingMore
-    if (completedLoadMore) {
-      loadMoreRequestRef.current = false
+    const restoreMessageId = restoreScrollMessageIdRef.current
+    if (restoreMessageId) {
+      restoreScrollMessageIdRef.current = null
+      const target = document.getElementById(`message-${restoreMessageId}`)
+      if (target) {
+        programmaticScroll.current = true
+        target.scrollIntoView({ behavior: 'auto', block: 'start' })
+        window.setTimeout(() => {
+          programmaticScroll.current = false
+        }, 0)
+      }
       prevPinRef.current = pinToTop
       prevUserIndexRef.current = lastUserIndex
-      prevFirstMessageIdRef.current = firstDisplayMessageId
       return
     }
 
@@ -320,7 +314,6 @@ function ChatMessageListComponent({
         !prevPinRef.current || prevUserIndexRef.current !== lastUserIndex
       prevPinRef.current = true
       prevUserIndexRef.current = lastUserIndex
-      prevFirstMessageIdRef.current = firstDisplayMessageId
       if (shouldPin && lastUserRef.current) {
         programmaticScroll.current = true
         lastUserRef.current.scrollIntoView({ behavior: 'auto', block: 'start' })
@@ -333,7 +326,6 @@ function ChatMessageListComponent({
 
     prevPinRef.current = false
     prevUserIndexRef.current = lastUserIndex
-    prevFirstMessageIdRef.current = firstDisplayMessageId
     if (anchorRef.current) {
       programmaticScroll.current = true
       anchorRef.current.scrollIntoView({ behavior: 'auto', block: 'end' })
@@ -342,11 +334,9 @@ function ChatMessageListComponent({
       }, 0)
     }
   }, [
-    firstDisplayMessageId,
-    isLoadingMore,
+    displayMessages,
     lastUserIndex,
     loading,
-    displayMessages.length,
     pinToTop,
     sessionKey,
   ])
@@ -357,7 +347,6 @@ function ChatMessageListComponent({
     const target = document.getElementById(`message-${jumpToMessageId}`)
     if (!target) return
 
-    // Search jump: bring the message into view and briefly highlight it.
     target.scrollIntoView({ behavior: 'smooth', block: 'center' })
     setHighlightedMessageId(jumpToMessageId)
     const timer = window.setTimeout(() => {
@@ -370,7 +359,6 @@ function ChatMessageListComponent({
   }, [jumpToMessageId, loading, displayMessages])
 
   return (
-    // mt-2 is to fix the prompt-input cut off
     <ChatContainerRoot className="flex-1 min-h-0 -mb-4">
       <ChatContainerContent className="pt-6" style={contentStyle}>
         {notice && noticePosition === 'start' ? notice : null}
@@ -388,23 +376,63 @@ function ChatMessageListComponent({
           </div>
         )}
         {empty && !notice ? (
-          (emptyState ?? <div aria-hidden></div>)
+          emptyState ?? <div aria-hidden></div>
         ) : hasGroup ? (
           <>
-            {displayMessages
-              .slice(0, groupStartIndex)
-              .map((chatMessage, index) => {
+            {displayMessages.slice(0, groupStartIndex).map((chatMessage, index) => {
+              const messageId =
+                typeof chatMessage.id === 'string' ? chatMessage.id : undefined
+              const messageKey = messageId || index
+              const forceActionsVisible =
+                typeof lastAssistantIndex === 'number' &&
+                index === lastAssistantIndex
+              const isLastAssistant =
+                typeof lastAssistantIndex === 'number' &&
+                index === lastAssistantIndex
+              const hasToolCalls =
+                chatMessage.role === 'assistant' &&
+                getToolCallsFromMessage(chatMessage).length > 0
+              return (
+                <MessageItem
+                  key={messageKey}
+                  message={chatMessage}
+                  toolResultsByCallId={
+                    hasToolCalls ? toolResultsByCallId : undefined
+                  }
+                  forceActionsVisible={forceActionsVisible}
+                  isStreaming={isLastAssistant && isStreaming}
+                  isLastAssistant={isLastAssistant}
+                  aggregatedSearchSources={
+                    isLastAssistant ? aggregatedSearchSources : undefined
+                  }
+                  messageDomId={messageId ? `message-${messageId}` : undefined}
+                  highlighted={highlightedMessageId === messageId}
+                  onRetry={onRetryMessage}
+                  onDismiss={onDismissMessage}
+                />
+              )
+            })}
+            <div
+              className="flex flex-col gap-[var(--opencami-msg-gap)]"
+              style={{ minHeight: `${Math.max(0, pinGroupMinHeight)}px` }}
+            >
+              {displayMessages.slice(groupStartIndex).map((chatMessage, index) => {
+                const realIndex = groupStartIndex + index
                 const messageId =
-                  typeof chatMessage.id === 'string'
-                    ? chatMessage.id
-                    : undefined
-                const messageKey = messageId || index
+                  typeof chatMessage.id === 'string' ? chatMessage.id : undefined
+                const messageKey = messageId || realIndex
                 const forceActionsVisible =
                   typeof lastAssistantIndex === 'number' &&
-                  index === lastAssistantIndex
+                  realIndex === lastAssistantIndex
                 const isLastAssistant =
                   typeof lastAssistantIndex === 'number' &&
-                  index === lastAssistantIndex
+                  realIndex === lastAssistantIndex
+                const wrapperRef =
+                  realIndex === lastUserIndex ? lastUserRef : undefined
+                const wrapperClassName =
+                  realIndex === lastUserIndex ? 'scroll-mt-0' : undefined
+                const wrapperScrollMarginTop =
+                  realIndex === lastUserIndex ? headerHeight : undefined
                 const hasToolCalls =
                   chatMessage.role === 'assistant' &&
                   getToolCallsFromMessage(chatMessage).length > 0
@@ -421,69 +449,16 @@ function ChatMessageListComponent({
                     aggregatedSearchSources={
                       isLastAssistant ? aggregatedSearchSources : undefined
                     }
-                    messageDomId={
-                      messageId ? `message-${messageId}` : undefined
-                    }
+                    wrapperRef={wrapperRef}
+                    wrapperClassName={wrapperClassName}
+                    wrapperScrollMarginTop={wrapperScrollMarginTop}
+                    messageDomId={messageId ? `message-${messageId}` : undefined}
                     highlighted={highlightedMessageId === messageId}
                     onRetry={onRetryMessage}
                     onDismiss={onDismissMessage}
                   />
                 )
               })}
-            {/* Keep the last exchange pinned while honoring current message density. */}
-            <div
-              className="flex flex-col gap-[var(--opencami-msg-gap)]"
-              style={{ minHeight: `${Math.max(0, pinGroupMinHeight)}px` }}
-            >
-              {displayMessages
-                .slice(groupStartIndex)
-                .map((chatMessage, index) => {
-                  const realIndex = groupStartIndex + index
-                  const messageId =
-                    typeof chatMessage.id === 'string'
-                      ? chatMessage.id
-                      : undefined
-                  const messageKey = messageId || realIndex
-                  const forceActionsVisible =
-                    typeof lastAssistantIndex === 'number' &&
-                    realIndex === lastAssistantIndex
-                  const isLastAssistant =
-                    typeof lastAssistantIndex === 'number' &&
-                    realIndex === lastAssistantIndex
-                  const wrapperRef =
-                    realIndex === lastUserIndex ? lastUserRef : undefined
-                  const wrapperClassName =
-                    realIndex === lastUserIndex ? 'scroll-mt-0' : undefined
-                  const wrapperScrollMarginTop =
-                    realIndex === lastUserIndex ? headerHeight : undefined
-                  const hasToolCalls =
-                    chatMessage.role === 'assistant' &&
-                    getToolCallsFromMessage(chatMessage).length > 0
-                  return (
-                    <MessageItem
-                      key={messageKey}
-                      message={chatMessage}
-                      toolResultsByCallId={
-                        hasToolCalls ? toolResultsByCallId : undefined
-                      }
-                      forceActionsVisible={forceActionsVisible}
-                      isStreaming={isLastAssistant && isStreaming}
-                      isLastAssistant={isLastAssistant}
-                      aggregatedSearchSources={
-                        isLastAssistant ? aggregatedSearchSources : undefined
-                      }
-                      wrapperRef={wrapperRef}
-                      wrapperClassName={wrapperClassName}
-                      wrapperScrollMarginTop={wrapperScrollMarginTop}
-                      messageDomId={
-                        messageId ? `message-${messageId}` : undefined
-                      }
-                      highlighted={highlightedMessageId === messageId}
-                      onRetry={onRetryMessage}
-                      onDismiss={onDismissMessage}
-                    />
-                  )
-                })}
               {showTypingIndicator ? (
                 <div className="py-2">
                   <TypingIndicator />
@@ -553,6 +528,21 @@ function ChatMessageListComponent({
       </ChatContainerContent>
     </ChatContainerRoot>
   )
+}
+
+function getMessageStableKey(message: GatewayMessage | undefined): string | null {
+  if (!message) return null
+  if (typeof message.id === 'string' && message.id.length > 0) {
+    return `id:${message.id}`
+  }
+  if (typeof message.clientId === 'string' && message.clientId.length > 0) {
+    return `client:${message.clientId}`
+  }
+  return [
+    message.role ?? '',
+    message.timestamp ?? '',
+    textFromMessage(message),
+  ].join('|')
 }
 
 function areChatMessageListEqual(

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -2,6 +2,7 @@ import {
   Suspense,
   lazy,
   memo,
+  useCallback,
   useDeferredValue,
   useEffect,
   useLayoutEffect,
@@ -49,6 +50,12 @@ type ChatMessageListProps = {
   onRetryMessage?: (message: GatewayMessage) => void
   /** Called when user clicks Dismiss on a failed message */
   onDismissMessage?: (message: GatewayMessage) => void
+  /** Whether there are earlier messages to load */
+  hasMore?: boolean
+  /** Called when user wants to load earlier messages */
+  onLoadMore?: () => void
+  /** True while an earlier history page is being fetched */
+  isLoadingMore?: boolean
 }
 
 function ChatMessageListComponent({
@@ -69,12 +76,17 @@ function ChatMessageListComponent({
   jumpToMessageId,
   onRetryMessage,
   onDismissMessage,
+  hasMore,
+  onLoadMore,
+  isLoadingMore = false,
 }: ChatMessageListProps) {
   const anchorRef = useRef<HTMLDivElement | null>(null)
   const lastUserRef = useRef<HTMLDivElement | null>(null)
   const programmaticScroll = useRef(false)
   const prevPinRef = useRef(pinToTop)
   const prevUserIndexRef = useRef<number | undefined>(undefined)
+  const prevFirstMessageIdRef = useRef<string | undefined>(undefined)
+  const loadMoreRequestRef = useRef(false)
   const [highlightedMessageId, setHighlightedMessageId] = useState<
     string | null
   >(null)
@@ -281,13 +293,34 @@ function ChatMessageListComponent({
       typeof lastTextAssistantIndex !== 'number' ||
       lastTextAssistantIndex > lastUserIndex)
 
+  const firstDisplayMessageId = displayMessages.find(
+    (message) => typeof message.id === 'string' && message.id.length > 0,
+  )?.id
+
+  const handleLoadMoreClick = useCallback(() => {
+    if (!onLoadMore || isLoadingMore) return
+    loadMoreRequestRef.current = true
+    onLoadMore()
+  }, [isLoadingMore, onLoadMore])
+
   useLayoutEffect(() => {
     if (loading) return
+
+    const completedLoadMore = loadMoreRequestRef.current && !isLoadingMore
+    if (completedLoadMore) {
+      loadMoreRequestRef.current = false
+      prevPinRef.current = pinToTop
+      prevUserIndexRef.current = lastUserIndex
+      prevFirstMessageIdRef.current = firstDisplayMessageId
+      return
+    }
+
     if (pinToTop) {
       const shouldPin =
         !prevPinRef.current || prevUserIndexRef.current !== lastUserIndex
       prevPinRef.current = true
       prevUserIndexRef.current = lastUserIndex
+      prevFirstMessageIdRef.current = firstDisplayMessageId
       if (shouldPin && lastUserRef.current) {
         programmaticScroll.current = true
         lastUserRef.current.scrollIntoView({ behavior: 'auto', block: 'start' })
@@ -300,6 +333,7 @@ function ChatMessageListComponent({
 
     prevPinRef.current = false
     prevUserIndexRef.current = lastUserIndex
+    prevFirstMessageIdRef.current = firstDisplayMessageId
     if (anchorRef.current) {
       programmaticScroll.current = true
       anchorRef.current.scrollIntoView({ behavior: 'auto', block: 'end' })
@@ -307,7 +341,15 @@ function ChatMessageListComponent({
         programmaticScroll.current = false
       }, 0)
     }
-  }, [loading, displayMessages.length, sessionKey, pinToTop, lastUserIndex])
+  }, [
+    firstDisplayMessageId,
+    isLoadingMore,
+    lastUserIndex,
+    loading,
+    displayMessages.length,
+    pinToTop,
+    sessionKey,
+  ])
 
   useEffect(() => {
     if (!jumpToMessageId || loading) return
@@ -332,6 +374,19 @@ function ChatMessageListComponent({
     <ChatContainerRoot className="flex-1 min-h-0 -mb-4">
       <ChatContainerContent className="pt-6" style={contentStyle}>
         {notice && noticePosition === 'start' ? notice : null}
+        {hasMore && onLoadMore && !loading && (
+          <div className="flex justify-center py-3">
+            <button
+              type="button"
+              className="text-xs text-primary-500 hover:text-primary-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-primary-400 dark:hover:text-primary-200 underline"
+              onClick={handleLoadMoreClick}
+              disabled={isLoadingMore}
+              aria-busy={isLoadingMore}
+            >
+              {isLoadingMore ? 'Loading earlier messages...' : 'Load earlier messages'}
+            </button>
+          </div>
+        )}
         {empty && !notice ? (
           (emptyState ?? <div aria-hidden></div>)
         ) : hasGroup ? (
@@ -521,7 +576,10 @@ function areChatMessageListEqual(
     prev.onFollowUpClick === next.onFollowUpClick &&
     prev.jumpToMessageId === next.jumpToMessageId &&
     prev.onRetryMessage === next.onRetryMessage &&
-    prev.onDismissMessage === next.onDismissMessage
+    prev.onDismissMessage === next.onDismissMessage &&
+    prev.hasMore === next.hasMore &&
+    prev.onLoadMore === next.onLoadMore &&
+    prev.isLoadingMore === next.isLoadingMore
   )
 }
 

--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -6,6 +6,7 @@ import { getMessageTimestamp, textFromMessage } from '../utils'
 import type { GatewayMessage, HistoryResponse } from '../types'
 
 const PAGE_SIZE = 50
+const LOAD_MORE_PAGE_SIZE = 150
 
 type UseChatHistoryInput = {
   activeFriendlyId: string
@@ -34,20 +35,7 @@ export function useChatHistory({
     activeFriendlyId,
     sessionKeyForHistory,
   )
-
-  const limitRef = useRef(PAGE_SIZE)
-  const hasMoreRef = useRef(false)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
-
-  const prevSessionRef = useRef(sessionKeyForHistory)
-  if (prevSessionRef.current !== sessionKeyForHistory) {
-    prevSessionRef.current = sessionKeyForHistory
-    limitRef.current = PAGE_SIZE
-    hasMoreRef.current = false
-    if (isLoadingMore) {
-      setIsLoadingMore(false)
-    }
-  }
 
   const historyQuery = useQuery({
     queryKey: historyKey,
@@ -58,27 +46,33 @@ export function useChatHistory({
       const optimisticMessages = getOptimisticMessages(cached?.messages)
       const cachedServerMessages = getServerMessages(cached?.messages)
 
-      const serverData = await fetchHistory({
-        sessionKey: sessionKeyForHistory,
-        friendlyId: activeFriendlyId,
-        limit: limitRef.current,
-      })
-
-      const mergedServerMessages = dedupeMessages(
-        serverData.messages,
-        cachedServerMessages,
+      const serverData = normalizeHistoryPage(
+        await fetchHistory({
+          sessionKey: sessionKeyForHistory,
+          friendlyId: activeFriendlyId,
+          limit: PAGE_SIZE + 1,
+        }),
+        PAGE_SIZE,
       )
-      const hasNewMessages = mergedServerMessages.length > cachedServerMessages.length
-      hasMoreRef.current =
-        isLoadingMore && !hasNewMessages
-          ? false
-          : (serverData.hasMore ?? false)
+
+      const latestIds = new Set(serverData.messages.map(messageIdentity))
+      const olderCachedMessages = cachedServerMessages.filter((message) => {
+        return !latestIds.has(messageIdentity(message))
+      })
+      const mergedServerMessages = dedupeMessages(
+        olderCachedMessages,
+        serverData.messages,
+      )
+      const hasMore =
+        olderCachedMessages.length > 0 && typeof cached?.hasMore === 'boolean'
+          ? cached.hasMore
+          : serverData.hasMore ?? false
 
       if (!optimisticMessages.length) {
         return {
           ...serverData,
           messages: mergedServerMessages,
-          hasMore: hasMoreRef.current,
+          hasMore,
         }
       }
 
@@ -88,7 +82,7 @@ export function useChatHistory({
           mergedServerMessages,
           optimisticMessages,
         ),
-        hasMore: hasMoreRef.current,
+        hasMore,
       }
     },
     enabled:
@@ -104,14 +98,59 @@ export function useChatHistory({
 
   const loadMore = useCallback(async () => {
     if (isLoadingMore || historyQuery.isFetching) return
+
+    const cached = queryClient.getQueryData(historyKey) as
+      | HistoryResponse
+      | undefined
+    const cachedMessages = Array.isArray(cached?.messages) ? cached.messages : []
+    const before = getOldestHistoryCursor(cachedMessages)
+    if (!before) return
+
     setIsLoadingMore(true)
-    limitRef.current += PAGE_SIZE * 3
     try {
-      await historyQuery.refetch()
+      const olderData = normalizeHistoryPage(
+        await fetchHistory({
+          sessionKey: sessionKeyForHistory,
+          friendlyId: activeFriendlyId,
+          limit: LOAD_MORE_PAGE_SIZE + 1,
+          before,
+        }),
+        LOAD_MORE_PAGE_SIZE,
+      )
+
+      const optimisticMessages = getOptimisticMessages(cachedMessages)
+      const currentServerMessages = getServerMessages(cachedMessages)
+      const mergedServerMessages = dedupeMessages(
+        olderData.messages,
+        currentServerMessages,
+      )
+      const prependedMessageCount =
+        mergedServerMessages.length - currentServerMessages.length
+
+      queryClient.setQueryData(historyKey, {
+        sessionKey:
+          olderData.sessionKey || cached?.sessionKey || sessionKeyForHistory,
+        sessionId: olderData.sessionId ?? cached?.sessionId,
+        messages: optimisticMessages.length
+          ? mergeOptimisticHistoryMessages(
+              mergedServerMessages,
+              optimisticMessages,
+            )
+          : mergedServerMessages,
+        hasMore:
+          prependedMessageCount > 0 ? (olderData.hasMore ?? false) : false,
+      } satisfies HistoryResponse)
     } finally {
       setIsLoadingMore(false)
     }
-  }, [historyQuery, isLoadingMore])
+  }, [
+    activeFriendlyId,
+    historyKey,
+    historyQuery.isFetching,
+    isLoadingMore,
+    queryClient,
+    sessionKeyForHistory,
+  ])
 
   const stableHistorySignatureRef = useRef('')
   const stableHistoryMessagesRef = useRef<Array<GatewayMessage>>([])
@@ -120,10 +159,7 @@ export function useChatHistory({
       ? historyQuery.data.messages
       : []
     const last = messages[messages.length - 1]
-    const lastId =
-      last && typeof (last as { id?: string }).id === 'string'
-        ? (last as { id?: string }).id
-        : ''
+    const lastId = typeof last?.id === 'string' ? last.id : ''
     const signature = `${messages.length}:${last?.role ?? ''}:${lastId}:${textFromMessage(last ?? { role: 'user', content: [] }).slice(-32)}`
     if (signature === stableHistorySignatureRef.current) {
       return stableHistoryMessagesRef.current
@@ -144,6 +180,9 @@ export function useChatHistory({
   const activeCanonicalKey = isNewChat
     ? 'new'
     : resolvedSessionKey || activeFriendlyId
+  const hasMore =
+    Boolean(historyQuery.data?.hasMore) &&
+    Boolean(getOldestHistoryCursor(historyMessages))
 
   return {
     historyQuery,
@@ -153,9 +192,23 @@ export function useChatHistory({
     resolvedSessionKey,
     activeCanonicalKey,
     sessionKeyForHistory,
-    hasMore: hasMoreRef.current,
+    hasMore,
     isLoadingMore,
     loadMore,
+  }
+}
+
+export function normalizeHistoryPage(
+  data: HistoryResponse,
+  visibleLimit: number,
+): HistoryResponse {
+  const messages = Array.isArray(data.messages) ? data.messages : []
+  const hasMore = data.hasMore ?? messages.length > visibleLimit
+
+  return {
+    ...data,
+    messages: hasMore ? messages.slice(messages.length - visibleLimit) : messages,
+    hasMore,
   }
 }
 
@@ -163,7 +216,11 @@ function getOptimisticMessages(
   messages: Array<GatewayMessage> | undefined,
 ): Array<GatewayMessage> {
   if (!Array.isArray(messages)) return []
-  return messages.filter((message) => isOptimisticMessage(message))
+  return messages.filter((message) => {
+    if (message.status === 'sending') return true
+    if (message.__optimisticId) return true
+    return Boolean(message.clientId)
+  })
 }
 
 function getServerMessages(
@@ -177,6 +234,54 @@ function isOptimisticMessage(message: GatewayMessage): boolean {
   if (message.status === 'sending') return true
   if (message.__optimisticId) return true
   return Boolean(message.clientId)
+}
+
+function getOldestHistoryCursor(
+  messages: Array<GatewayMessage> | undefined,
+): string | undefined {
+  if (!Array.isArray(messages)) return undefined
+  const oldestMessage = messages.find((message) => !isOptimisticMessage(message))
+  if (!oldestMessage) return undefined
+  if (typeof oldestMessage.id === 'string' && oldestMessage.id.trim().length > 0) {
+    return oldestMessage.id.trim()
+  }
+  return undefined
+}
+
+function dedupeMessages(...chunks: Array<Array<GatewayMessage>>): Array<GatewayMessage> {
+  const merged: Array<GatewayMessage> = []
+  const seen = new Set<string>()
+
+  for (const chunk of chunks) {
+    for (const message of chunk) {
+      const key = messageIdentity(message)
+      if (seen.has(key)) continue
+      seen.add(key)
+      merged.push(message)
+    }
+  }
+
+  return merged
+}
+
+function messageIdentity(message: GatewayMessage): string {
+  if (typeof message.id === 'string' && message.id.length > 0) {
+    return `id:${message.id}`
+  }
+  if (typeof message.clientId === 'string' && message.clientId.length > 0) {
+    return `client:${message.clientId}`
+  }
+  if (
+    typeof message.__optimisticId === 'string' &&
+    message.__optimisticId.length > 0
+  ) {
+    return `optimistic:${message.__optimisticId}`
+  }
+  return [
+    message.role ?? '',
+    message.timestamp ?? '',
+    textFromMessage(message),
+  ].join('|')
 }
 
 function mergeOptimisticHistoryMessages(
@@ -219,40 +324,4 @@ function mergeOptimisticHistoryMessages(
   }
 
   return merged
-}
-
-function dedupeMessages(...chunks: Array<Array<GatewayMessage>>): Array<GatewayMessage> {
-  const merged: Array<GatewayMessage> = []
-  const seen = new Set<string>()
-
-  for (const chunk of chunks) {
-    for (const message of chunk) {
-      const key = messageIdentity(message)
-      if (seen.has(key)) continue
-      seen.add(key)
-      merged.push(message)
-    }
-  }
-
-  return merged
-}
-
-function messageIdentity(message: GatewayMessage): string {
-  if (typeof message.id === 'string' && message.id.length > 0) {
-    return `id:${message.id}`
-  }
-  if (typeof message.clientId === 'string' && message.clientId.length > 0) {
-    return `client:${message.clientId}`
-  }
-  if (
-    typeof message.__optimisticId === 'string' &&
-    message.__optimisticId.length > 0
-  ) {
-    return `optimistic:${message.__optimisticId}`
-  }
-  return [
-    message.role ?? '',
-    message.timestamp ?? '',
-    textFromMessage(message),
-  ].join('|')
 }

--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -1,9 +1,11 @@
-import { useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useQuery, type QueryClient } from '@tanstack/react-query'
 
 import { chatQueryKeys, fetchHistory } from '../chat-queries'
 import { getMessageTimestamp, textFromMessage } from '../utils'
 import type { GatewayMessage, HistoryResponse } from '../types'
+
+const PAGE_SIZE = 50
 
 type UseChatHistoryInput = {
   activeFriendlyId: string
@@ -32,34 +34,61 @@ export function useChatHistory({
     activeFriendlyId,
     sessionKeyForHistory,
   )
+
+  const limitRef = useRef(PAGE_SIZE)
+  const hasMoreRef = useRef(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+
+  const prevSessionRef = useRef(sessionKeyForHistory)
+  if (prevSessionRef.current !== sessionKeyForHistory) {
+    prevSessionRef.current = sessionKeyForHistory
+    limitRef.current = PAGE_SIZE
+    hasMoreRef.current = false
+    if (isLoadingMore) {
+      setIsLoadingMore(false)
+    }
+  }
+
   const historyQuery = useQuery({
     queryKey: historyKey,
     queryFn: async function fetchHistoryForSession() {
       const cached = queryClient.getQueryData(historyKey) as
         | HistoryResponse
         | undefined
-      const optimisticMessages = Array.isArray(cached?.messages)
-        ? cached.messages.filter((message) => {
-            if (message.status === 'sending') return true
-            if (message.__optimisticId) return true
-            return Boolean(message.clientId)
-          })
-        : []
+      const optimisticMessages = getOptimisticMessages(cached?.messages)
+      const cachedServerMessages = getServerMessages(cached?.messages)
 
       const serverData = await fetchHistory({
         sessionKey: sessionKeyForHistory,
         friendlyId: activeFriendlyId,
+        limit: limitRef.current,
       })
-      if (!optimisticMessages.length) return serverData
 
-      const merged = mergeOptimisticHistoryMessages(
+      const mergedServerMessages = dedupeMessages(
         serverData.messages,
-        optimisticMessages,
+        cachedServerMessages,
       )
+      const hasNewMessages = mergedServerMessages.length > cachedServerMessages.length
+      hasMoreRef.current =
+        isLoadingMore && !hasNewMessages
+          ? false
+          : (serverData.hasMore ?? false)
+
+      if (!optimisticMessages.length) {
+        return {
+          ...serverData,
+          messages: mergedServerMessages,
+          hasMore: hasMoreRef.current,
+        }
+      }
 
       return {
         ...serverData,
-        messages: merged,
+        messages: mergeOptimisticHistoryMessages(
+          mergedServerMessages,
+          optimisticMessages,
+        ),
+        hasMore: hasMoreRef.current,
       }
     },
     enabled:
@@ -72,6 +101,17 @@ export function useChatHistory({
     },
     gcTime: 1000 * 60 * 10,
   })
+
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || historyQuery.isFetching) return
+    setIsLoadingMore(true)
+    limitRef.current += PAGE_SIZE * 3
+    try {
+      await historyQuery.refetch()
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [historyQuery, isLoadingMore])
 
   const stableHistorySignatureRef = useRef('')
   const stableHistoryMessagesRef = useRef<Array<GatewayMessage>>([])
@@ -113,7 +153,30 @@ export function useChatHistory({
     resolvedSessionKey,
     activeCanonicalKey,
     sessionKeyForHistory,
+    hasMore: hasMoreRef.current,
+    isLoadingMore,
+    loadMore,
   }
+}
+
+function getOptimisticMessages(
+  messages: Array<GatewayMessage> | undefined,
+): Array<GatewayMessage> {
+  if (!Array.isArray(messages)) return []
+  return messages.filter((message) => isOptimisticMessage(message))
+}
+
+function getServerMessages(
+  messages: Array<GatewayMessage> | undefined,
+): Array<GatewayMessage> {
+  if (!Array.isArray(messages)) return []
+  return messages.filter((message) => !isOptimisticMessage(message))
+}
+
+function isOptimisticMessage(message: GatewayMessage): boolean {
+  if (message.status === 'sending') return true
+  if (message.__optimisticId) return true
+  return Boolean(message.clientId)
 }
 
 function mergeOptimisticHistoryMessages(
@@ -156,4 +219,40 @@ function mergeOptimisticHistoryMessages(
   }
 
   return merged
+}
+
+function dedupeMessages(...chunks: Array<Array<GatewayMessage>>): Array<GatewayMessage> {
+  const merged: Array<GatewayMessage> = []
+  const seen = new Set<string>()
+
+  for (const chunk of chunks) {
+    for (const message of chunk) {
+      const key = messageIdentity(message)
+      if (seen.has(key)) continue
+      seen.add(key)
+      merged.push(message)
+    }
+  }
+
+  return merged
+}
+
+function messageIdentity(message: GatewayMessage): string {
+  if (typeof message.id === 'string' && message.id.length > 0) {
+    return `id:${message.id}`
+  }
+  if (typeof message.clientId === 'string' && message.clientId.length > 0) {
+    return `client:${message.clientId}`
+  }
+  if (
+    typeof message.__optimisticId === 'string' &&
+    message.__optimisticId.length > 0
+  ) {
+    return `optimistic:${message.__optimisticId}`
+  }
+  return [
+    message.role ?? '',
+    message.timestamp ?? '',
+    textFromMessage(message),
+  ].join('|')
 }

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -39,6 +39,7 @@ export type ImageContent = {
 export type MessageContent = TextContent | ToolCallContent | ThinkingContent | ImageContent
 
 export type GatewayMessage = {
+  id?: string
   role?: string
   content?: Array<MessageContent>
   toolCallId?: string
@@ -46,6 +47,8 @@ export type GatewayMessage = {
   details?: Record<string, unknown>
   isError?: boolean
   timestamp?: number
+  clientId?: string
+  status?: string
   [key: string]: unknown
   __optimisticId?: string
 }

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -69,6 +69,7 @@ export type HistoryResponse = {
   sessionKey: string
   sessionId?: string
   messages: Array<GatewayMessage>
+  hasMore?: boolean
 }
 
 export type SessionMeta = {


### PR DESCRIPTION
## Summary
- Reduce initial history fetch from **200 to 50 messages** — faster load for most conversations
- Add **"Load earlier messages"** button at the top of the message list when `hasMore` is detected
- Each click loads 150 more messages by increasing the limit and refetching
- `/api/history` now supports a `before` cursor param (passed through to gateway RPC — used if gateway supports it, harmlessly ignored if not)
- `hasMore` is inferred from response: `messages.length >= limit`

## Test plan
- [ ] Open a short conversation (<50 messages) — no "Load earlier" button should appear
- [ ] Open a long conversation (>50 messages) — "Load earlier messages" should appear at top
- [ ] Click "Load earlier messages" — more messages should load, button disappears when all loaded
- [ ] Streaming still works correctly after loading more
- [ ] Session switching resets the limit back to 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)