### PR TITLE
test: unit tests for streaming event processing

### DIFF
--- a/src/__tests__/hooks/streaming-helpers.test.ts
+++ b/src/__tests__/hooks/streaming-helpers.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  handleAgentEvent,
+  deriveToolStatus,
+  asRecord,
+  normalizeString,
+} from '@/screens/chat/hooks/streaming-helpers'
+import type { StreamingState } from '@/screens/chat/hooks/use-streaming'
+
+// ─── Helper: run setState updaters and return final state ────────────────
+
+function applySetState(
+  initial: StreamingState,
+  fn: (setState: (updater: StreamingState | ((prev: StreamingState) => StreamingState)) => void) => void,
+): StreamingState {
+  let state = initial
+  const setState = (updater: StreamingState | ((prev: StreamingState) => StreamingState)) => {
+    state = typeof updater === 'function' ? updater(state) : updater
+  }
+  fn(setState)
+  return state
+}
+
+const EMPTY_STATE: StreamingState = {
+  active: false,
+  text: '',
+  tools: [],
+  contentBlocks: [],
+  sessionKey: null,
+}
+
+// ─── normalizeString ─────────────────────────────────────────────────────
+
+describe('normalizeString', () => {
+  it('trims strings', () => {
+    expect(normalizeString('  hello  ')).toBe('hello')
+  })
+
+  it('returns empty string for non-strings', () => {
+    expect(normalizeString(null)).toBe('')
+    expect(normalizeString(undefined)).toBe('')
+    expect(normalizeString(42)).toBe('')
+    expect(normalizeString({})).toBe('')
+    expect(normalizeString(true)).toBe('')
+  })
+})
+
+// ─── asRecord ────────────────────────────────────────────────────────────
+
+describe('asRecord', () => {
+  it('returns objects as records', () => {
+    const obj = { foo: 'bar' }
+    expect(asRecord(obj)).toBe(obj)
+  })
+
+  it('returns arrays as records (they are objects)', () => {
+    const arr = [1, 2, 3]
+    expect(asRecord(arr)).toBe(arr)
+  })
+
+  it('returns null for primitives', () => {
+    expect(asRecord(null)).toBeNull()
+    expect(asRecord(undefined)).toBeNull()
+    expect(asRecord('')).toBeNull()
+    expect(asRecord(0)).toBeNull()
+    expect(asRecord(false)).toBeNull()
+  })
+})
+
+// ─── deriveToolStatus ────────────────────────────────────────────────────
+
+describe('deriveToolStatus', () => {
+  it('returns explicit phase from data', () => {
+    expect(deriveToolStatus('tool.call', { phase: 'running' })).toBe('running')
+    expect(deriveToolStatus('tool.call', { status: 'done' })).toBe('done')
+    expect(deriveToolStatus('tool.call', { state: 'error' })).toBe('error')
+  })
+
+  it('infers done from result/output stream names', () => {
+    expect(deriveToolStatus('tool.result', null)).toBe('done')
+    expect(deriveToolStatus('tool.output', null)).toBe('done')
+  })
+
+  it('infers running from call stream names', () => {
+    expect(deriveToolStatus('tool.call', null)).toBe('running')
+  })
+
+  it('defaults to running for unknown stream names', () => {
+    expect(deriveToolStatus('tool.something', null)).toBe('running')
+  })
+})
+
+// ─── handleAgentEvent: assistant text deltas ─────────────────────────────
+
+describe('handleAgentEvent — assistant text', () => {
+  it('accumulates text from delta events', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      const options = {
+        setState,
+        activeRuns: new Set<string>(),
+        anyRunSeen: { current: false },
+      }
+
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'Hello' }, runId: 'r1' },
+        'session-1',
+        options,
+      )
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'world' }, runId: 'r1' },
+        'session-1',
+        options,
+      )
+    })
+
+    // normalizeString trims each delta, so consecutive deltas are concatenated directly
+    expect(state.text).toBe('Helloworld')
+    expect(state.contentBlocks).toHaveLength(1)
+    expect(state.contentBlocks[0]).toEqual({ kind: 'text', text: 'Helloworld' })
+    expect(state.sessionKey).toBe('session-1')
+  })
+
+  it('uses payload sessionKey over fallback', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'hi' }, sessionKey: 'real-key', runId: 'r1' },
+        'fallback-key',
+        {
+          setState,
+          activeRuns: new Set<string>(),
+          anyRunSeen: { current: false },
+        },
+      )
+    })
+
+    expect(state.sessionKey).toBe('real-key')
+  })
+
+  it('calls onAssistantDelta callback', () => {
+    const onDelta = vi.fn()
+    applySetState(EMPTY_STATE, (setState) => {
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'hey' }, runId: 'r1' },
+        'key',
+        {
+          setState,
+          onAssistantDelta: onDelta,
+          activeRuns: new Set<string>(),
+          anyRunSeen: { current: false },
+        },
+      )
+    })
+
+    expect(onDelta).toHaveBeenCalledWith({ text: 'hey', sessionKey: 'key' })
+  })
+
+  it('ignores assistant events with empty text', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: '   ' }, runId: 'r1' },
+        'key',
+        {
+          setState,
+          activeRuns: new Set<string>(),
+          anyRunSeen: { current: false },
+        },
+      )
+    })
+
+    expect(state.text).toBe('')
+    expect(state.contentBlocks).toHaveLength(0)
+  })
+})
+
+// ─── handleAgentEvent: tool events ───────────────────────────────────────
+
+describe('handleAgentEvent — tool events', () => {
+  it('creates tool content block from tool.call event', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      handleAgentEvent(
+        {
+          stream: 'tool.call',
+          data: {
+            toolCallId: 'tc-1',
+            toolName: 'web_search',
+            arguments: { query: 'test' },
+          },
+          runId: 'r1',
+        },
+        'key',
+        {
+          setState,
+          activeRuns: new Set<string>(),
+          anyRunSeen: { current: false },
+        },
+      )
+    })
+
+    expect(state.tools).toHaveLength(1)
+    expect(state.tools[0]).toEqual({ id: 'tc-1', name: 'web_search', status: 'running' })
+    expect(state.contentBlocks).toHaveLength(1)
+    expect(state.contentBlocks[0]).toEqual({
+      kind: 'tool',
+      id: 'tc-1',
+      name: 'web_search',
+      status: 'running',
+      arguments: { query: 'test' },
+      output: undefined,
+    })
+  })
+
+  it('updates existing tool block with result', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      const options = {
+        setState,
+        activeRuns: new Set<string>(),
+        anyRunSeen: { current: false },
+      }
+
+      // tool.call first
+      handleAgentEvent(
+        {
+          stream: 'tool.call',
+          data: { toolCallId: 'tc-1', toolName: 'web_search', arguments: { query: 'q' } },
+          runId: 'r1',
+        },
+        'key',
+        options,
+      )
+
+      // then tool.result
+      handleAgentEvent(
+        {
+          stream: 'tool.result',
+          data: { toolCallId: 'tc-1', toolName: 'web_search', result: 'found it' },
+          runId: 'r1',
+        },
+        'key',
+        options,
+      )
+    })
+
+    expect(state.contentBlocks).toHaveLength(1)
+    const block = state.contentBlocks[0]
+    expect(block).toMatchObject({
+      kind: 'tool',
+      id: 'tc-1',
+      status: 'done',
+      arguments: { query: 'q' }, // preserved from call event
+      output: 'found it',
+    })
+    expect(state.tools[0].status).toBe('done')
+  })
+
+  it('preserves text/tool interleaving order', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      const options = {
+        setState,
+        activeRuns: new Set<string>(),
+        anyRunSeen: { current: false },
+      }
+
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'Before tool' }, runId: 'r1' },
+        'key',
+        options,
+      )
+      handleAgentEvent(
+        {
+          stream: 'tool.call',
+          data: { toolCallId: 'tc-1', toolName: 'exec' },
+          runId: 'r1',
+        },
+        'key',
+        options,
+      )
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'After tool' }, runId: 'r1' },
+        'key',
+        options,
+      )
+    })
+
+    expect(state.contentBlocks).toHaveLength(3)
+    expect(state.contentBlocks[0]).toMatchObject({ kind: 'text', text: 'Before tool' })
+    expect(state.contentBlocks[1]).toMatchObject({ kind: 'tool', name: 'exec' })
+    expect(state.contentBlocks[2]).toMatchObject({ kind: 'text', text: 'After tool' })
+  })
+
+  it('generates fallback tool ID from runId and name', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      handleAgentEvent(
+        {
+          stream: 'tool.call',
+          data: { toolName: 'my_tool' },
+          runId: 'run-42',
+        },
+        'key',
+        {
+          setState,
+          activeRuns: new Set<string>(),
+          anyRunSeen: { current: false },
+        },
+      )
+    })
+
+    expect(state.tools[0].id).toBe('run-42:my_tool')
+  })
+})
+
+// ─── handleAgentEvent: lifecycle tracking ────────────────────────────────
+
+describe('handleAgentEvent — lifecycle', () => {
+  it('tracks active runs', () => {
+    const activeRuns = new Set<string>()
+    const anyRunSeen = { current: false }
+
+    applySetState(EMPTY_STATE, (setState) => {
+      const options = { setState, activeRuns, anyRunSeen }
+
+      handleAgentEvent(
+        { stream: 'assistant', data: { delta: 'hi' }, runId: 'r1' },
+        'key',
+        options,
+      )
+      expect(activeRuns.has('r1')).toBe(true)
+      expect(anyRunSeen.current).toBe(true)
+    })
+  })
+
+  it('removes run on lifecycle end', () => {
+    const activeRuns = new Set<string>()
+    const anyRunSeen = { current: false }
+
+    applySetState(EMPTY_STATE, (setState) => {
+      const options = { setState, activeRuns, anyRunSeen }
+
+      // Start
+      handleAgentEvent(
+        { stream: 'lifecycle', data: { phase: 'start' }, runId: 'r1' },
+        'key',
+        options,
+      )
+      expect(activeRuns.has('r1')).toBe(true)
+
+      // End
+      handleAgentEvent(
+        { stream: 'lifecycle', data: { phase: 'end' }, runId: 'r1' },
+        'key',
+        options,
+      )
+      expect(activeRuns.has('r1')).toBe(false)
+    })
+  })
+
+  it('removes run on lifecycle error/abort', () => {
+    const activeRuns = new Set<string>()
+    const anyRunSeen = { current: false }
+
+    applySetState(EMPTY_STATE, (setState) => {
+      const options = { setState, activeRuns, anyRunSeen }
+
+      handleAgentEvent(
+        { stream: 'lifecycle', data: { phase: 'start' }, runId: 'r1' },
+        'key',
+        options,
+      )
+      handleAgentEvent(
+        { stream: 'lifecycle', data: { phase: 'error' }, runId: 'r1' },
+        'key',
+        options,
+      )
+      expect(activeRuns.has('r1')).toBe(false)
+    })
+  })
+
+  it('handles null/invalid payloads gracefully', () => {
+    const state = applySetState(EMPTY_STATE, (setState) => {
+      handleAgentEvent(null, 'key', {
+        setState,
+        activeRuns: new Set<string>(),
+        anyRunSeen: { current: false },
+      })
+      handleAgentEvent(42, 'key', {
+        setState,
+        activeRuns: new Set<string>(),
+        anyRunSeen: { current: false },
+      })
+      handleAgentEvent('invalid', 'key', {
+        setState,
+        activeRuns: new Set<string>(),
+        anyRunSeen: { current: false },
+      })
+    })
+
+    // Should not crash, state unchanged
+    expect(state.text).toBe('')
+    expect(state.contentBlocks).toHaveLength(0)
+  })
+})

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -11,7 +11,7 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   // Clear localStorage between tests
-  if (typeof localStorage !== 'undefined') {
+  if (typeof localStorage !== 'undefined' && typeof localStorage.clear === 'function') {
     localStorage.clear()
   }
 })

--- a/src/screens/chat/hooks/streaming-helpers.ts
+++ b/src/screens/chat/hooks/streaming-helpers.ts
@@ -1,0 +1,161 @@
+import type { Dispatch, SetStateAction } from 'react'
+import type { StreamContentBlock, StreamingState } from './use-streaming'
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+type RawAgentPayload = {
+  runId?: unknown
+  sessionKey?: unknown
+  stream?: unknown
+  data?: unknown
+}
+
+export type HandleAgentEventOptions = {
+  setState: Dispatch<SetStateAction<StreamingState>>
+  onAssistantDelta?: (payload: { text: string; sessionKey: string }) => void
+  activeRuns: Set<string>
+  anyRunSeen: { current: boolean }
+}
+
+// ─── Event Handling ──────────────────────────────────────────────────────
+
+export function handleAgentEvent(
+  payload: unknown,
+  fallbackSessionKey: string,
+  options: HandleAgentEventOptions,
+) {
+  const agentPayload = asRecord(payload) as RawAgentPayload | null
+  const stream = normalizeString(agentPayload?.stream)
+  const runId = normalizeString(agentPayload?.runId)
+  const sessionKey = normalizeString(agentPayload?.sessionKey) || fallbackSessionKey
+  const streamData = asRecord(agentPayload?.data)
+
+  if (runId) {
+    options.anyRunSeen.current = true
+    if (stream === 'lifecycle') {
+      const phase = normalizeString(streamData?.phase)
+      if (phase === 'end' || phase === 'error' || phase === 'abort') {
+        options.activeRuns.delete(runId)
+      } else if (phase) {
+        options.activeRuns.add(runId)
+      }
+    } else {
+      options.activeRuns.add(runId)
+    }
+  }
+
+  // ── Assistant text deltas ─────────────────────────────────────────
+  if (stream === 'assistant') {
+    const text = normalizeString(streamData?.delta) || normalizeString(streamData?.text)
+    if (!text) return
+    options.setState((prev) => {
+      // Append to the last text block, or create a new one
+      const blocks = [...prev.contentBlocks]
+      const lastBlock = blocks[blocks.length - 1]
+      if (lastBlock?.kind === 'text') {
+        blocks[blocks.length - 1] = { ...lastBlock, text: lastBlock.text + text }
+      } else {
+        blocks.push({ kind: 'text', text })
+      }
+      return {
+        ...prev,
+        sessionKey,
+        text: prev.text + text,
+        contentBlocks: blocks,
+      }
+    })
+    options.onAssistantDelta?.({ text, sessionKey })
+    return
+  }
+
+  // ── Tool events ───────────────────────────────────────────────────
+  if (!stream.includes('tool')) return
+
+  const toolId =
+    normalizeString(streamData?.toolCallId) ||
+    normalizeString(streamData?.id) ||
+    normalizeString(streamData?.callId) ||
+    `${runId || 'tool'}:${normalizeString(streamData?.toolName) || normalizeString(streamData?.name) || 'unknown'}`
+  const toolName =
+    normalizeString(streamData?.toolName) ||
+    normalizeString(streamData?.name) ||
+    'Tool'
+  const toolStatus = deriveToolStatus(stream, streamData)
+
+  // Extract tool input (arguments) and output from the event data.
+  // Gateway events may carry these under various field names.
+  const toolArgs =
+    asRecord(streamData?.arguments) ||
+    asRecord(streamData?.input) ||
+    asRecord(streamData?.params) ||
+    null
+  const toolOutput =
+    normalizeString(streamData?.result) ||
+    normalizeString(streamData?.output) ||
+    (stream.includes('result') ? normalizeString(streamData?.text) : '')
+
+  options.setState((prev) => {
+    // Update tools array (backward compat)
+    const tools = [...prev.tools]
+    const toolIndex = tools.findIndex((tool) => tool.id === toolId)
+    const nextTool = { id: toolId, name: toolName, status: toolStatus }
+    if (toolIndex >= 0) {
+      tools[toolIndex] = nextTool
+    } else {
+      tools.push(nextTool)
+    }
+
+    // Update contentBlocks — preserves interleaving order
+    const blocks = [...prev.contentBlocks]
+    const blockIndex = blocks.findIndex(
+      (b) => b.kind === 'tool' && b.id === toolId,
+    )
+    const existingBlock = blockIndex >= 0
+      ? (blocks[blockIndex] as StreamContentBlock & { kind: 'tool' })
+      : null
+    const nextBlock: StreamContentBlock = {
+      kind: 'tool',
+      name: toolName,
+      id: toolId,
+      status: toolStatus,
+      // Merge: keep existing arguments/output if new event doesn't carry them
+      arguments: toolArgs ?? existingBlock?.arguments,
+      output: toolOutput || existingBlock?.output || undefined,
+    }
+    if (blockIndex >= 0) {
+      blocks[blockIndex] = nextBlock
+    } else {
+      blocks.push(nextBlock)
+    }
+
+    return {
+      ...prev,
+      sessionKey,
+      tools,
+      contentBlocks: blocks,
+    }
+  })
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+export function deriveToolStatus(stream: string, data: Record<string, unknown> | null): string {
+  const explicitStatus =
+    normalizeString(data?.phase) ||
+    normalizeString(data?.status) ||
+    normalizeString(data?.state)
+  if (explicitStatus) return explicitStatus
+  if (stream.includes('result') || stream.includes('output')) return 'done'
+  if (stream.includes('call')) return 'running'
+  return 'running'
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+export function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}

--- a/src/screens/chat/hooks/use-streaming.ts
+++ b/src/screens/chat/hooks/use-streaming.ts
@@ -2,9 +2,12 @@ import {
   useCallback,
   useRef,
   useState,
-  type Dispatch,
-  type SetStateAction,
 } from 'react'
+import {
+  handleAgentEvent,
+  asRecord,
+  normalizeString,
+} from './streaming-helpers'
 
 // ─── Types ──────────────────────────────────────────────────────────────
 
@@ -35,13 +38,6 @@ type RawGatewayEvent = {
   payload?: unknown
   seq?: number
   stateVersion?: number
-}
-
-type RawAgentPayload = {
-  runId?: unknown
-  sessionKey?: unknown
-  stream?: unknown
-  data?: unknown
 }
 
 const INITIAL_STATE: StreamingState = {
@@ -243,152 +239,4 @@ export function useStreaming(options: {
   }, [])
 
   return { streaming: state, startStream: start, stopStream: stop }
-}
-
-// ─── Event Handling ─────────────────────────────────────────────────────
-
-function handleAgentEvent(
-  payload: unknown,
-  fallbackSessionKey: string,
-  options: {
-    setState: Dispatch<SetStateAction<StreamingState>>
-    onAssistantDelta?: (payload: { text: string; sessionKey: string }) => void
-    activeRuns: Set<string>
-    anyRunSeen: { current: boolean }
-  },
-) {
-  const agentPayload = asRecord(payload) as RawAgentPayload | null
-  const stream = normalizeString(agentPayload?.stream)
-  const runId = normalizeString(agentPayload?.runId)
-  const sessionKey = normalizeString(agentPayload?.sessionKey) || fallbackSessionKey
-  const streamData = asRecord(agentPayload?.data)
-
-  if (runId) {
-    options.anyRunSeen.current = true
-    if (stream === 'lifecycle') {
-      const phase = normalizeString(streamData?.phase)
-      if (phase === 'end' || phase === 'error' || phase === 'abort') {
-        options.activeRuns.delete(runId)
-      } else if (phase) {
-        options.activeRuns.add(runId)
-      }
-    } else {
-      options.activeRuns.add(runId)
-    }
-  }
-
-  // ── Assistant text deltas ─────────────────────────────────────────
-  if (stream === 'assistant') {
-    const text = normalizeString(streamData?.delta) || normalizeString(streamData?.text)
-    if (!text) return
-    options.setState((prev) => {
-      // Append to the last text block, or create a new one
-      const blocks = [...prev.contentBlocks]
-      const lastBlock = blocks[blocks.length - 1]
-      if (lastBlock?.kind === 'text') {
-        blocks[blocks.length - 1] = { ...lastBlock, text: lastBlock.text + text }
-      } else {
-        blocks.push({ kind: 'text', text })
-      }
-      return {
-        ...prev,
-        sessionKey,
-        text: prev.text + text,
-        contentBlocks: blocks,
-      }
-    })
-    options.onAssistantDelta?.({ text, sessionKey })
-    return
-  }
-
-  // ── Tool events ───────────────────────────────────────────────────
-  if (!stream.includes('tool')) return
-
-  const toolId =
-    normalizeString(streamData?.toolCallId) ||
-    normalizeString(streamData?.id) ||
-    normalizeString(streamData?.callId) ||
-    `${runId || 'tool'}:${normalizeString(streamData?.toolName) || normalizeString(streamData?.name) || 'unknown'}`
-  const toolName =
-    normalizeString(streamData?.toolName) ||
-    normalizeString(streamData?.name) ||
-    'Tool'
-  const toolStatus = deriveToolStatus(stream, streamData)
-
-  // Extract tool input (arguments) and output from the event data.
-  // Gateway events may carry these under various field names.
-  const toolArgs =
-    asRecord(streamData?.arguments) ||
-    asRecord(streamData?.input) ||
-    asRecord(streamData?.params) ||
-    null
-  const toolOutput =
-    normalizeString(streamData?.result) ||
-    normalizeString(streamData?.output) ||
-    (stream.includes('result') ? normalizeString(streamData?.text) : '')
-
-  options.setState((prev) => {
-    // Update tools array (backward compat)
-    const tools = [...prev.tools]
-    const toolIndex = tools.findIndex((tool) => tool.id === toolId)
-    const nextTool = { id: toolId, name: toolName, status: toolStatus }
-    if (toolIndex >= 0) {
-      tools[toolIndex] = nextTool
-    } else {
-      tools.push(nextTool)
-    }
-
-    // Update contentBlocks — preserves interleaving order
-    const blocks = [...prev.contentBlocks]
-    const blockIndex = blocks.findIndex(
-      (b) => b.kind === 'tool' && b.id === toolId,
-    )
-    const existingBlock = blockIndex >= 0
-      ? (blocks[blockIndex] as StreamContentBlock & { kind: 'tool' })
-      : null
-    const nextBlock: StreamContentBlock = {
-      kind: 'tool',
-      name: toolName,
-      id: toolId,
-      status: toolStatus,
-      // Merge: keep existing arguments/output if new event doesn't carry them
-      arguments: toolArgs ?? existingBlock?.arguments,
-      output: toolOutput || existingBlock?.output || undefined,
-    }
-    if (blockIndex >= 0) {
-      blocks[blockIndex] = nextBlock
-    } else {
-      blocks.push(nextBlock)
-    }
-
-    return {
-      ...prev,
-      sessionKey,
-      tools,
-      contentBlocks: blocks,
-    }
-  })
-}
-
-// ─── Helpers ────────────────────────────────────────────────────────────
-
-function deriveToolStatus(stream: string, data: Record<string, unknown> | null): string {
-  const explicitStatus =
-    normalizeString(data?.phase) ||
-    normalizeString(data?.status) ||
-    normalizeString(data?.state)
-  if (explicitStatus) return explicitStatus
-  if (stream.includes('result') || stream.includes('output')) return 'done'
-  if (stream.includes('call')) return 'running'
-  return 'running'
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object'
-    ? (value as Record<string, unknown>)
-    : null
-}
-
-function normalizeString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : ''
 }


### PR DESCRIPTION
## Summary
- Extract `handleAgentEvent`, `deriveToolStatus`, `asRecord`, `normalizeString` from `use-streaming.ts` into `streaming-helpers.ts` for independent testability
- Add **21 unit tests** covering all streaming event processing logic:
  - `normalizeString` — trimming, non-string handling
  - `asRecord` — object detection, primitive rejection
  - `deriveToolStatus` — explicit status fields, stream name inference
  - `handleAgentEvent` — text accumulation, tool block creation/update, argument/output merging, text/tool interleaving order, lifecycle run tracking, graceful null/invalid payload handling
- Fix pre-existing `localStorage.clear` crash in test setup

## Test plan
- [x] All 21 tests pass: `pnpm exec vitest run src/__tests__/hooks/streaming-helpers.test.ts`
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)