### PR TITLE
feat: route chat inference through OpenClaw gateway

### DIFF
--- a/src/lib/openclaw-client.ts
+++ b/src/lib/openclaw-client.ts
@@ -1,0 +1,153 @@
+type ChatMessage = {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+type ChatCompletionResponse = {
+  choices?: Array<{
+    message?: {
+      content?: string
+    }
+  }>
+}
+
+const OPENCLAW_GATEWAY_URL = 'http://127.0.0.1:18789/v1/chat/completions'
+const OPENCLAW_MODEL = 'openclaw'
+const DEFAULT_TIMEOUT_MS = 10000
+
+function getGatewayToken(): string | null {
+  return (
+    process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
+    process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
+    null
+  )
+}
+
+async function chatCompletion(
+  messages: ChatMessage[],
+  options?: { maxTokens?: number; temperature?: number; timeoutMs?: number },
+): Promise<string> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  )
+
+  try {
+    const token = getGatewayToken()
+    const response = await fetch(OPENCLAW_GATEWAY_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        model: OPENCLAW_MODEL,
+        messages,
+        max_tokens: options?.maxTokens ?? 200,
+        temperature: options?.temperature ?? 0.7,
+      }),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '')
+      throw new Error(
+        `OpenClaw Gateway error: ${response.status}${errorText ? ` ${errorText}` : ''}`,
+      )
+    }
+
+    const data = (await response.json()) as ChatCompletionResponse
+    const content = data.choices?.[0]?.message?.content?.trim() || ''
+    if (!content) {
+      throw new Error('OpenClaw Gateway returned empty content')
+    }
+
+    return content
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('OpenClaw Gateway request timed out')
+    }
+    throw error instanceof Error ? error : new Error(String(error))
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+function parseFollowUps(text: string): string[] {
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.replace(/^\d+[.)\s]+/, '').trim())
+    .map((line) => line.replace(/^[-•*]\s*/, '').trim())
+    .map((line) => line.replace(/^["']|["']$/g, '').trim())
+    .filter((line) => line.length > 0 && line.length < 150)
+
+  return lines.slice(0, 3)
+}
+
+export async function generateTitleViaOpenclaw(message: string): Promise<string> {
+  const systemPrompt = `Generate a concise 3-6 word title for this conversation.
+Rules:
+- No quotes or punctuation at the end
+- Capture the main topic or intent
+- Be specific, not generic
+- Use title case`
+
+  return chatCompletion(
+    [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: message },
+    ],
+    { maxTokens: 60, temperature: 0.3 },
+  )
+}
+
+export async function generateFollowUpsViaOpenclaw(
+  responseText: string,
+  contextSummary?: string,
+): Promise<string[]> {
+  const truncatedResponse =
+    responseText.length > 1500 ? `${responseText.slice(0, 1500)}...` : responseText
+  const trimmedSummary = contextSummary?.slice(0, 500).trim() || ''
+
+  const userPrompt = trimmedSummary
+    ? `Context: ${trimmedSummary}\n\nAssistant's response:\n${truncatedResponse}`
+    : `Assistant's response:\n${truncatedResponse}`
+
+  const systemPrompt = `You are a helpful assistant that generates follow-up question suggestions.
+Given the assistant's last response, generate exactly 3 short, natural follow-up questions the user might want to ask.
+
+Rules:
+- Each suggestion should be a single, concise question (under 60 characters preferred)
+- Make them contextually relevant to the response
+- Vary the types: clarification, deeper exploration, practical application
+- Use natural, conversational language
+- Do not number them or add any prefix
+
+Output format: Return ONLY the 3 questions, one per line, nothing else.`
+
+  const response = await chatCompletion(
+    [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ],
+    { maxTokens: 200, temperature: 0.7 },
+  )
+
+  return parseFollowUps(response)
+}
+
+export async function isOpenclawAvailable(): Promise<boolean> {
+  try {
+    await chatCompletion([{ role: 'user', content: 'Hi' }], {
+      maxTokens: 1,
+      temperature: 0,
+      timeoutMs: 5000,
+    })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/routes/api/follow-ups.ts
+++ b/src/routes/api/follow-ups.ts
@@ -1,51 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { gatewayRpc } from '../../server/gateway'
+import { generateFollowUpsViaOpenclaw } from '../../lib/openclaw-client'
 
 /**
  * API Route: /api/follow-ups
  *
- * Generates contextual follow-up suggestions using the LLM via the OpenClaw Gateway.
- * Returns 3 suggestions based on the assistant's last response and conversation context.
+ * Generates contextual follow-up suggestions using the OpenClaw Gateway.
  */
-
-const FOLLOW_UP_SYSTEM_PROMPT = `You are a helpful assistant that generates follow-up question suggestions.
-Given the assistant's last response, generate exactly 3 short, natural follow-up questions the user might want to ask.
-
-Rules:
-- Each suggestion should be a single, concise question (under 60 characters preferred)
-- Make them contextually relevant to the response
-- Vary the types: clarification, deeper exploration, practical application
-- Use natural, conversational language
-- Do not number them or add any prefix
-
-Output format: Return ONLY the 3 questions, one per line, nothing else.`
 
 type FollowUpRequest = {
   responseText: string
   contextSummary?: string
-}
-
-type ChatCompleteResponse = {
-  content?: string
-  message?: { content?: string }
-  choices?: Array<{ message?: { content?: string } }>
-}
-
-function parseFollowUps(text: string): string[] {
-  const lines = text
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    // Remove any numbered prefixes like "1." or "1)"
-    .map((line) => line.replace(/^\d+[.)\s]+/, '').trim())
-    // Remove bullet points
-    .map((line) => line.replace(/^[-•*]\s*/, '').trim())
-    // Remove quotes
-    .map((line) => line.replace(/^["']|["']$/g, '').trim())
-    .filter((line) => line.length > 0 && line.length < 150)
-
-  return lines.slice(0, 3)
 }
 
 export const Route = createFileRoute('/api/follow-ups')({
@@ -62,46 +27,17 @@ export const Route = createFileRoute('/api/follow-ups')({
             return json({ ok: true, suggestions: [] })
           }
 
-          // Truncate to keep the request fast - we only need enough context
-          const truncatedResponse =
-            responseText.length > 1500
-              ? responseText.slice(0, 1500) + '...'
-              : responseText
-
           const contextSummary =
-            typeof body.contextSummary === 'string'
-              ? body.contextSummary.slice(0, 500)
-              : ''
+            typeof body.contextSummary === 'string' ? body.contextSummary : undefined
 
-          const userPrompt = contextSummary
-            ? `Context: ${contextSummary}\n\nAssistant's response:\n${truncatedResponse}`
-            : `Assistant's response:\n${truncatedResponse}`
-
-          // Use chat.complete for a lightweight, fast completion
-          // Using a fast model and low token limit for speed
-          const res = await gatewayRpc<ChatCompleteResponse>('chat.complete', {
-            messages: [
-              { role: 'system', content: FOLLOW_UP_SYSTEM_PROMPT },
-              { role: 'user', content: userPrompt },
-            ],
-            maxTokens: 200,
-            temperature: 0.7,
-            // Use session's default model (no hardcoding!)
-          })
-
-          // Handle various response formats from the gateway
-          const content =
-            res.content ||
-            res.message?.content ||
-            res.choices?.[0]?.message?.content ||
-            ''
-
-          const suggestions = parseFollowUps(content)
+          const suggestions = await generateFollowUpsViaOpenclaw(
+            responseText,
+            contextSummary,
+          )
 
           return json({ ok: true, suggestions })
         } catch (err) {
           console.error('[follow-ups] Error generating suggestions:', err)
-          // Return empty array on error - the client will use fallback suggestions
           return json({
             ok: false,
             error: err instanceof Error ? err.message : String(err),

--- a/src/routes/api/llm-features.ts
+++ b/src/routes/api/llm-features.ts
@@ -1,17 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import {
-  generateSessionTitle,
-  generateFollowUps,
-  testApiKey,
-} from '../../lib/llm-client'
+  generateFollowUpsViaOpenclaw,
+  generateTitleViaOpenclaw,
+  isOpenclawAvailable,
+} from '../../lib/openclaw-client'
 
 /**
  * API Routes: /api/llm-features
- * 
- * Endpoints for LLM-enhanced features using OpenAI API.
- * Supports both user-provided API key (from request header) and
- * server environment variable OPENAI_API_KEY.
+ *
+ * Endpoints for OpenClaw-powered title generation and follow-up suggestions.
  */
 
 type TitleRequest = {
@@ -24,120 +22,22 @@ type FollowUpsRequest = {
 
 type StatusResponse = {
   ok: boolean
-  hasEnvKey: boolean
-  hasOpenRouterKey?: boolean
-  hasKilocodeKey?: boolean
+  available: boolean
   error?: string
 }
 
 type TitleResponse = {
   ok: boolean
   title?: string
-  source?: 'llm' | 'heuristic'
+  source?: 'openclaw' | 'heuristic'
   error?: string
 }
 
 type FollowUpsResponse = {
   ok: boolean
   suggestions?: string[]
-  source?: 'llm' | 'heuristic'
+  source?: 'openclaw' | 'heuristic'
   error?: string
-}
-
-type TestKeyResponse = {
-  ok: boolean
-  valid?: boolean
-  error?: string
-}
-
-/**
- * Get API key from request header or environment
- * Priority: Header (user-provided) > Environment variable
- */
-type LlmConfig = {
-  apiKey: string | null
-  baseUrl: string | null
-  model: string | null
-  error: string | null
-}
-
-const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
-const PRESET_BASE_URL_ORIGINS = new Set([
-  'https://api.openai.com',
-  'https://openrouter.ai',
-  'https://api.kilo.ai',
-  'http://localhost:11434',
-  'http://127.0.0.1:11434',
-])
-
-function getOrigin(rawBaseUrl: string): string | null {
-  try {
-    return new URL(rawBaseUrl).origin
-  } catch {
-    return null
-  }
-}
-
-function isAllowedClientBaseUrl(rawBaseUrl: string): boolean {
-  const parsed = new URL(rawBaseUrl)
-  if (!['http:', 'https:'].includes(parsed.protocol)) return false
-  if (parsed.username || parsed.password) return false
-
-  const hostname = parsed.hostname.toLowerCase()
-  const isLocalHost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
-  if (!isLocalHost && parsed.protocol !== 'https:') return false
-
-  const origin = parsed.origin
-  if (PRESET_BASE_URL_ORIGINS.has(origin)) return true
-
-  const envBaseUrl = process.env.LLM_BASE_URL?.trim()
-  const envOrigin = envBaseUrl ? getOrigin(envBaseUrl) : null
-  return Boolean(envOrigin && envOrigin === origin)
-}
-
-function detectProvider(rawBaseUrl: string | null): 'openai' | 'openrouter' | 'kilocode' {
-  const baseUrl = rawBaseUrl?.toLowerCase() || ''
-  if (baseUrl.includes('openrouter.ai')) return 'openrouter'
-  if (baseUrl.includes('kilo.ai')) return 'kilocode'
-  return 'openai'
-}
-
-function getLlmConfig(request: Request): LlmConfig {
-  // API key: header > env provider key
-  const headerKey = request.headers.get('X-OpenAI-API-Key')
-  const headerBaseUrl = request.headers.get('X-LLM-Base-URL')?.trim() || null
-  const envBaseUrl = process.env.LLM_BASE_URL?.trim() || null
-
-  if (headerBaseUrl) {
-    const origin = getOrigin(headerBaseUrl)
-    if (!origin || !isAllowedClientBaseUrl(headerBaseUrl)) {
-      return {
-        apiKey: null,
-        baseUrl: null,
-        model: null,
-        error: 'Disallowed X-LLM-Base-URL value',
-      }
-    }
-  }
-
-  const baseUrl = headerBaseUrl || envBaseUrl || DEFAULT_OPENAI_BASE_URL
-  const provider = detectProvider(baseUrl)
-  const envKey = provider === 'openrouter'
-    ? (process.env.OPENROUTER_API_KEY?.trim() || process.env.OPENAI_API_KEY?.trim())
-    : provider === 'kilocode'
-      ? (process.env.KILOCODE_API_KEY?.trim() || process.env.OPENAI_API_KEY?.trim())
-      : process.env.OPENAI_API_KEY?.trim()
-  const apiKey = headerKey?.trim() || envKey || null
-
-  // Model: header > env default
-  const model = request.headers.get('X-LLM-Model')?.trim() || process.env.LLM_MODEL?.trim() || null
-
-  return { apiKey, baseUrl, model, error: null }
-}
-
-/** @deprecated Use getLlmConfig instead */
-function getApiKey(request: Request): string | null {
-  return getLlmConfig(request).apiKey
 }
 
 /**
@@ -145,36 +45,26 @@ function getApiKey(request: Request): string | null {
  * Extracts first 5-6 meaningful words
  */
 function generateHeuristicTitle(message: string): string {
-  // Remove code blocks
   let text = message.replace(/```[\s\S]*?```/g, ' ')
-  // Remove inline code
   text = text.replace(/`[^`]+`/g, ' ')
-  // Remove URLs
   text = text.replace(/https?:\/\/[^\s]+/g, ' ')
-  // Remove special characters but keep basic punctuation
   text = text.replace(/[^\w\s.,!?'-]/g, ' ')
-  // Collapse whitespace
   text = text.replace(/\s+/g, ' ').trim()
 
-  // Split into words and take first meaningful ones
   const words = text.split(/\s+/).filter((word) => {
-    // Filter out very short words unless they're important
-    if (word.length <= 2 && !['AI', 'ML', 'UI', 'UX', 'API', 'CSS', 'JS'].includes(word.toUpperCase())) {
+    if (
+      word.length <= 2 &&
+      !['AI', 'ML', 'UI', 'UX', 'API', 'CSS', 'JS'].includes(word.toUpperCase())
+    ) {
       return false
     }
     return true
   })
 
-  // Take first 5-6 words
   const titleWords = words.slice(0, 6)
-  
-  // Join and clean up
   let title = titleWords.join(' ')
-  
-  // Remove trailing punctuation except for meaningful ones
   title = title.replace(/[.,!?]+$/, '')
-  
-  // Truncate if too long
+
   if (title.length > 60) {
     title = title.slice(0, 57) + '...'
   }
@@ -185,117 +75,67 @@ function generateHeuristicTitle(message: string): string {
 export const Route = createFileRoute('/api/llm-features')({
   server: {
     handlers: {
-      /**
-       * GET /api/llm-features - Check LLM features status
-       */
       GET: async () => {
         try {
-          const hasEnvKey = Boolean(process.env.OPENAI_API_KEY?.trim())
-          const hasOpenRouterKey = Boolean(process.env.OPENROUTER_API_KEY?.trim())
-          const hasKilocodeKey = Boolean(process.env.KILOCODE_API_KEY?.trim())
-          
-          return json({
+          const available = await isOpenclawAvailable()
+          return json<StatusResponse>({
             ok: true,
-            hasEnvKey,
-            hasOpenRouterKey,
-            hasKilocodeKey,
+            available,
           })
         } catch (err) {
           return json<StatusResponse>({
             ok: false,
-            hasEnvKey: false,
+            available: false,
             error: err instanceof Error ? err.message : String(err),
           })
         }
       },
 
-      /**
-       * POST /api/llm-features - Handle LLM feature requests
-       * 
-       * Request body should include an "action" field:
-       * - action: "title" - Generate session title
-       * - action: "followups" - Generate follow-up suggestions
-       * - action: "test" - Test API key validity
-       */
       POST: async ({ request }) => {
         try {
-          const body = await request.json().catch(() => ({})) as Record<string, unknown>
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
           const action = body.action as string
 
           switch (action) {
             case 'title': {
               const { message } = body as TitleRequest & { action: string }
-              
-              if (!message || typeof message !== 'string' || message.trim().length < 3) {
-                return json<TitleResponse>({
-                  ok: false,
-                  error: 'Message is required and must be at least 3 characters',
-                })
-              }
 
-              const llmConfig = getLlmConfig(request)
-              if (llmConfig.error) {
-                return json<TitleResponse>({
-                  ok: false,
-                  error: llmConfig.error,
-                }, { status: 400 })
-              }
-              
-              // If no API key and no Ollama-style local provider, use heuristic
-              if (!llmConfig.apiKey && !llmConfig.baseUrl?.includes('localhost')) {
-                const title = generateHeuristicTitle(message)
-                return json<TitleResponse>({
-                  ok: true,
-                  title,
-                  source: 'heuristic',
-                })
+              if (!message || typeof message !== 'string' || message.trim().length < 3) {
+                return json<TitleResponse>(
+                  {
+                    ok: false,
+                    error: 'Message is required and must be at least 3 characters',
+                  },
+                  { status: 400 },
+                )
               }
 
               try {
-                const title = await generateSessionTitle(message, {
-                  apiKey: llmConfig.apiKey || '',
-                  ...(llmConfig.baseUrl ? { baseUrl: llmConfig.baseUrl } : {}),
-                  ...(llmConfig.model ? { model: llmConfig.model } : {}),
-                })
+                const title = await generateTitleViaOpenclaw(message)
                 return json<TitleResponse>({
                   ok: true,
                   title,
-                  source: 'llm',
+                  source: 'openclaw',
                 })
               } catch (err) {
-                // Fall back to heuristic on error
                 console.error('[llm-features] Title generation error:', err)
-                const title = generateHeuristicTitle(message)
                 return json<TitleResponse>({
                   ok: true,
-                  title,
+                  title: generateHeuristicTitle(message),
                   source: 'heuristic',
-                  error: err instanceof Error ? err.message : 'LLM error, used heuristic',
+                  error: err instanceof Error ? err.message : 'OpenClaw error, used heuristic',
                 })
               }
             }
 
             case 'followups': {
               const { conversationContext } = body as FollowUpsRequest & { action: string }
-              
-              if (!conversationContext || typeof conversationContext !== 'string' || conversationContext.trim().length < 10) {
-                return json<FollowUpsResponse>({
-                  ok: true,
-                  suggestions: [],
-                  source: 'heuristic',
-                })
-              }
 
-              const llmConfig = getLlmConfig(request)
-              if (llmConfig.error) {
-                return json<FollowUpsResponse>({
-                  ok: false,
-                  error: llmConfig.error,
-                }, { status: 400 })
-              }
-              
-              // If no API key and no local provider, return empty
-              if (!llmConfig.apiKey && !llmConfig.baseUrl?.includes('localhost')) {
+              if (
+                !conversationContext ||
+                typeof conversationContext !== 'string' ||
+                conversationContext.trim().length < 10
+              ) {
                 return json<FollowUpsResponse>({
                   ok: true,
                   suggestions: [],
@@ -304,15 +144,11 @@ export const Route = createFileRoute('/api/llm-features')({
               }
 
               try {
-                const suggestions = await generateFollowUps(conversationContext, {
-                  apiKey: llmConfig.apiKey || '',
-                  ...(llmConfig.baseUrl ? { baseUrl: llmConfig.baseUrl } : {}),
-                  ...(llmConfig.model ? { model: llmConfig.model } : {}),
-                })
+                const suggestions = await generateFollowUpsViaOpenclaw(conversationContext)
                 return json<FollowUpsResponse>({
                   ok: true,
                   suggestions,
-                  source: 'llm',
+                  source: 'openclaw',
                 })
               } catch (err) {
                 console.error('[llm-features] Follow-ups generation error:', err)
@@ -320,58 +156,37 @@ export const Route = createFileRoute('/api/llm-features')({
                   ok: true,
                   suggestions: [],
                   source: 'heuristic',
-                  error: err instanceof Error ? err.message : 'LLM error',
+                  error: err instanceof Error ? err.message : 'OpenClaw error',
                 })
               }
             }
 
             case 'test': {
-              const llmConfig = getLlmConfig(request)
-              if (llmConfig.error) {
-                return json<TestKeyResponse>({
-                  ok: false,
-                  error: llmConfig.error,
-                }, { status: 400 })
-              }
-              
-              if (!llmConfig.apiKey && !llmConfig.baseUrl?.includes('localhost')) {
-                return json<TestKeyResponse>({
-                  ok: false,
-                  error: 'API key required (or use Ollama for keyless access)',
-                })
-              }
-
-              try {
-                const valid = await testApiKey({
-                  apiKey: llmConfig.apiKey || '',
-                  ...(llmConfig.baseUrl ? { baseUrl: llmConfig.baseUrl } : {}),
-                  ...(llmConfig.model ? { model: llmConfig.model } : {}),
-                })
-                return json<TestKeyResponse>({
-                  ok: true,
-                  valid,
-                })
-              } catch (err) {
-                return json<TestKeyResponse>({
-                  ok: true,
-                  valid: false,
-                  error: err instanceof Error ? err.message : 'Test failed',
-                })
-              }
+              const available = await isOpenclawAvailable()
+              return json<StatusResponse>({
+                ok: true,
+                available,
+              })
             }
 
             default:
-              return json({
-                ok: false,
-                error: `Unknown action: ${action}. Valid actions: title, followups, test`,
-              }, { status: 400 })
+              return json(
+                {
+                  ok: false,
+                  error: `Unknown action: ${action}. Valid actions: title, followups, test`,
+                },
+                { status: 400 },
+              )
           }
         } catch (err) {
           console.error('[llm-features] Error:', err)
-          return json({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          }, { status: 500 })
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
         }
       },
     },

--- a/src/screens/chat/components/follow-up-suggestions.tsx
+++ b/src/screens/chat/components/follow-up-suggestions.tsx
@@ -5,15 +5,10 @@ import { useFollowUpSuggestions } from '../hooks/use-follow-up-suggestions'
 import { cn } from '@/lib/utils'
 
 type FollowUpSuggestionsProps = {
-  /** The assistant's response text to generate follow-ups from */
   responseText: string
-  /** Optional conversation context summary for better suggestions */
   contextSummary?: string
-  /** Callback when a suggestion is clicked */
   onSuggestionClick: (suggestion: string) => void
-  /** Whether suggestions are disabled (e.g., while waiting for response) */
   disabled?: boolean
-  /** Additional class name for the container */
   className?: string
 }
 
@@ -33,7 +28,6 @@ function FollowUpSuggestionsComponent({
     },
   )
 
-  // Don't render if no suggestions and not loading
   if (suggestions.length === 0 && !isLoading) {
     return null
   }
@@ -53,7 +47,7 @@ function FollowUpSuggestionsComponent({
                 className="animate-spin text-primary-400"
               />
             </span>
-          ) : source === 'llm' ? (
+          ) : source === 'openclaw' ? (
             'AI suggestions'
           ) : (
             'Follow-up suggestions'
@@ -74,7 +68,6 @@ function FollowUpSuggestionsComponent({
               'focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:ring-offset-1',
               'transition-all duration-150 cursor-pointer',
               'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary-50 disabled:hover:border-primary-200',
-              // Subtle animation when suggestions update from heuristic to LLM
               isLoading && 'opacity-75',
             )}
           >

--- a/src/screens/chat/hooks/use-follow-up-suggestions.ts
+++ b/src/screens/chat/hooks/use-follow-up-suggestions.ts
@@ -1,13 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { getHeuristicFollowUpTexts } from '../lib/follow-up-generator'
-import { getLlmHeaders, useLlmSettingsStore } from '@/hooks/use-llm-settings'
 
 type UseFollowUpSuggestionsOptions = {
-  /** Minimum response length to trigger suggestions */
   minResponseLength?: number
-  /** Timeout for LLM request in ms */
   timeoutMs?: number
-  /** Whether to skip LLM and use heuristics only (overrides settings) */
   heuristicsOnly?: boolean
 }
 
@@ -15,25 +11,18 @@ type UseFollowUpSuggestionsResult = {
   suggestions: string[]
   isLoading: boolean
   error: string | null
-  /** Source of current suggestions: 'llm', 'heuristic', or null */
-  source: 'llm' | 'heuristic' | null
+  source: 'openclaw' | 'heuristic' | null
 }
 
-/**
- * Fetch LLM-generated follow-up suggestions from the LLM API
- */
-async function fetchLlmFollowUps(
+async function fetchFollowUpsViaOpenclaw(
   conversationContext: string,
   signal?: AbortSignal,
 ): Promise<string[]> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...getLlmHeaders(),
-  }
-
   const res = await fetch('/api/llm-features', {
     method: 'POST',
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({
       action: 'followups',
       conversationContext,
@@ -59,43 +48,22 @@ async function fetchLlmFollowUps(
   return []
 }
 
-/**
- * Hook for fetching smart follow-up suggestions.
- *
- * Uses LLM-powered generation via OpenAI API when enabled in settings,
- * with graceful fallback to client-side heuristics if the LLM request
- * fails or times out.
- */
 export function useFollowUpSuggestions(
   responseText: string,
   contextSummary?: string,
   options?: UseFollowUpSuggestionsOptions,
 ): UseFollowUpSuggestionsResult {
-  // Get LLM settings
-  const llmSettings = useLlmSettingsStore((state) => state.settings)
-  const useLlmFollowUps = llmSettings.useLlmFollowUps
+  const { minResponseLength = 50, heuristicsOnly = false } = options ?? {}
 
-  const {
-    minResponseLength = 50,
-    timeoutMs = 8000,
-    // Use heuristics only if explicitly set OR if LLM follow-ups are disabled
-    heuristicsOnly: forceHeuristicsOnly,
-  } = options ?? {}
-
-  // Determine if we should use heuristics only
-  const heuristicsOnly = forceHeuristicsOnly ?? !useLlmFollowUps
-  
   const [suggestions, setSuggestions] = useState<string[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [source, setSource] = useState<'llm' | 'heuristic' | null>(null)
+  const [source, setSource] = useState<'openclaw' | 'heuristic' | null>(null)
 
-  // Track the response text to avoid duplicate requests
   const lastResponseRef = useRef<string>('')
   const abortControllerRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
-    // Skip if response is too short
     if (!responseText || responseText.trim().length < minResponseLength) {
       setSuggestions([])
       setSource(null)
@@ -104,19 +72,16 @@ export function useFollowUpSuggestions(
       return
     }
 
-    // Skip if we already processed this response
     const responseKey = responseText.slice(0, 200) + responseText.length
     if (responseKey === lastResponseRef.current) {
       return
     }
     lastResponseRef.current = responseKey
 
-    // Cancel any in-flight request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
     }
 
-    // Use heuristics only mode
     if (heuristicsOnly) {
       const heuristicSuggestions = getHeuristicFollowUpTexts(responseText)
       setSuggestions(heuristicSuggestions)
@@ -126,57 +91,35 @@ export function useFollowUpSuggestions(
       return
     }
 
-    // Start LLM request
     const controller = new AbortController()
     abortControllerRef.current = controller
     setIsLoading(true)
     setError(null)
 
-    // Show heuristic suggestions immediately while LLM loads
     const heuristicSuggestions = getHeuristicFollowUpTexts(responseText)
     setSuggestions(heuristicSuggestions)
     setSource('heuristic')
 
-    // Build context for the API call
     const conversationContext = contextSummary
       ? `Context: ${contextSummary}\n\nAssistant's response:\n${responseText.slice(0, 2000)}`
       : `Assistant's response:\n${responseText.slice(0, 2000)}`
 
-    // Use OpenAI API via our endpoint
-    fetchLlmFollowUps(conversationContext, controller.signal)
-      .then((llmSuggestions) => {
-        if (controller.signal.aborted) {
-          return
-        }
+    fetchFollowUpsViaOpenclaw(conversationContext, controller.signal)
+      .then((openclawSuggestions) => {
+        if (controller.signal.aborted) return
 
-        if (llmSuggestions.length > 0) {
-          setSuggestions(llmSuggestions)
-          setSource('llm')
+        if (openclawSuggestions.length > 0) {
+          setSuggestions(openclawSuggestions)
+          setSource('openclaw')
         }
         setIsLoading(false)
       })
       .catch((err) => {
         if (controller.signal.aborted) return
-        // Keep heuristic suggestions on error
         setError(err instanceof Error ? err.message : String(err))
         setIsLoading(false)
       })
-
-    return () => {
-      // Don't abort on re-render - let the request complete
-      // Only abort gets called on unmount which is fine
-    }
-  }, [
-    responseText,
-    contextSummary,
-    minResponseLength,
-    timeoutMs,
-    heuristicsOnly,
-    llmSettings.llmApiKey,
-    llmSettings.llmBaseUrl,
-    llmSettings.llmModel,
-    llmSettings.llmProvider,
-  ])
+  }, [responseText, contextSummary, minResponseLength, heuristicsOnly])
 
   return { suggestions, isLoading, error, source }
 }

--- a/src/screens/chat/hooks/use-smart-title.ts
+++ b/src/screens/chat/hooks/use-smart-title.ts
@@ -1,9 +1,8 @@
 import { useCallback, useRef, useState } from 'react'
-import { getLlmHeaders, useLlmSettingsStore } from '@/hooks/use-llm-settings'
 
 type GenerateTitleResult = {
   title: string
-  source: 'llm' | 'heuristic'
+  source: 'openclaw' | 'heuristic'
   error?: string
 }
 
@@ -11,106 +10,85 @@ type UseSmartTitleResult = {
   generateTitle: (message: string) => Promise<GenerateTitleResult>
   isGenerating: boolean
   lastTitle: string | null
-  lastSource: 'llm' | 'heuristic' | null
+  lastSource: 'openclaw' | 'heuristic' | null
 }
 
-/**
- * Hook for generating smart session titles
- * 
- * Uses LLM-powered title generation via OpenAI API when enabled,
- * with automatic fallback to heuristic generation.
- */
 export function useSmartTitle(): UseSmartTitleResult {
-  const llmSettings = useLlmSettingsStore((state) => state.settings)
   const [isGenerating, setIsGenerating] = useState(false)
   const [lastTitle, setLastTitle] = useState<string | null>(null)
-  const [lastSource, setLastSource] = useState<'llm' | 'heuristic' | null>(null)
+  const [lastSource, setLastSource] = useState<'openclaw' | 'heuristic' | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const generateTitle = useCallback(
-    async (message: string): Promise<GenerateTitleResult> => {
-      // Cancel any in-flight request
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-      }
+  const generateTitle = useCallback(async (message: string): Promise<GenerateTitleResult> => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+    }
 
-      const controller = new AbortController()
-      abortControllerRef.current = controller
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+    setIsGenerating(true)
 
-      setIsGenerating(true)
-
-      try {
-        const headers: Record<string, string> = {
+    try {
+      const res = await fetch('/api/llm-features', {
+        method: 'POST',
+        headers: {
           'Content-Type': 'application/json',
-          ...getLlmHeaders(),
-        }
+        },
+        body: JSON.stringify({
+          action: 'title',
+          message,
+        }),
+        signal: controller.signal,
+      })
 
-        const res = await fetch('/api/llm-features', {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            action: 'title',
-            message,
-          }),
-          signal: controller.signal,
-        })
-
-        if (!res.ok) {
-          throw new Error(`API error: ${res.status}`)
-        }
-
-        const data = (await res.json()) as {
-          ok: boolean
-          title?: string
-          source?: 'llm' | 'heuristic'
-          error?: string
-        }
-
-        if (controller.signal.aborted) {
-          throw new Error('Aborted')
-        }
-
-        const rawTitle = data.title || message.slice(0, 50)
-        const title = rawTitle.length > 64 ? rawTitle.slice(0, 61) + '...' : rawTitle
-        const source = data.source || 'heuristic'
-
-        setLastTitle(title)
-        setLastSource(source)
-
-        return {
-          title,
-          source,
-          error: data.error,
-        }
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
-          throw err
-        }
-
-        // Fallback to simple heuristic
-        const fallbackTitle = generateHeuristicTitle(message)
-        setLastTitle(fallbackTitle)
-        setLastSource('heuristic')
-
-        return {
-          title: fallbackTitle,
-          source: 'heuristic',
-          error: err instanceof Error ? err.message : 'Unknown error',
-        }
-      } finally {
-        setIsGenerating(false)
-        if (abortControllerRef.current === controller) {
-          abortControllerRef.current = null
-        }
+      if (!res.ok) {
+        throw new Error(`API error: ${res.status}`)
       }
-    },
-    [
-      llmSettings.llmApiKey,
-      llmSettings.llmBaseUrl,
-      llmSettings.llmModel,
-      llmSettings.llmProvider,
-    ],
-  )
+
+      const data = (await res.json()) as {
+        ok: boolean
+        title?: string
+        source?: 'openclaw' | 'heuristic'
+        error?: string
+      }
+
+      if (controller.signal.aborted) {
+        throw new Error('Aborted')
+      }
+
+      const rawTitle = data.title || message.slice(0, 50)
+      const title = rawTitle.length > 64 ? rawTitle.slice(0, 61) + '...' : rawTitle
+      const source = data.source || 'heuristic'
+
+      setLastTitle(title)
+      setLastSource(source)
+
+      return {
+        title,
+        source,
+        error: data.error,
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw err
+      }
+
+      const fallbackTitle = generateHeuristicTitle(message)
+      setLastTitle(fallbackTitle)
+      setLastSource('heuristic')
+
+      return {
+        title: fallbackTitle,
+        source: 'heuristic',
+        error: err instanceof Error ? err.message : 'Unknown error',
+      }
+    } finally {
+      setIsGenerating(false)
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = null
+      }
+    }
+  }, [])
 
   return {
     generateTitle,
@@ -120,22 +98,13 @@ export function useSmartTitle(): UseSmartTitleResult {
   }
 }
 
-/**
- * Generate a simple heuristic title from message text
- */
 function generateHeuristicTitle(message: string): string {
-  // Remove code blocks
   let text = message.replace(/```[\s\S]*?```/g, ' ')
-  // Remove inline code
   text = text.replace(/`[^`]+`/g, ' ')
-  // Remove URLs
   text = text.replace(/https?:\/\/[^\s]+/g, ' ')
-  // Remove special characters
   text = text.replace(/[^\w\s.,!?'-]/g, ' ')
-  // Collapse whitespace
   text = text.replace(/\s+/g, ' ').trim()
 
-  // Split into words
   const words = text.split(/\s+/).filter((word) => {
     if (word.length <= 2) {
       const upper = word.toUpperCase()
@@ -144,11 +113,8 @@ function generateHeuristicTitle(message: string): string {
     return true
   })
 
-  // Take first 5-6 words
   const titleWords = words.slice(0, 6)
   let title = titleWords.join(' ')
-
-  // Clean up
   title = title.replace(/[.,!?]+$/, '')
 
   if (title.length > 60) {
@@ -158,9 +124,6 @@ function generateHeuristicTitle(message: string): string {
   return title || message.slice(0, 50)
 }
 
-/**
- * Check if LLM titles are enabled
- */
 export function useLlmTitlesEnabled(): boolean {
-  return useLlmSettingsStore((state) => state.settings.useLlmTitles)
+  return true
 }


### PR DESCRIPTION
## Summary
- add a lightweight OpenClaw gateway client for title and follow-up generation
- swap `/api/llm-features` and `/api/follow-ups` off the legacy OpenAI path
- remove client-side LLM headers and settings dependencies from smart titles and follow-up suggestions
- relabel OpenClaw-backed suggestions in the chat UI

## Testing
- `pnpm -s exec tsc --noEmit` *(fails on pre-existing unrelated type errors in `src/screens/files/components/files-sidebar.tsx`)*
- `pnpm -s exec tsc --noEmit 2>&1 | rg "openclaw-client|src/routes/api/llm-features|src/routes/api/follow-ups|use-follow-up-suggestions|use-smart-title|follow-up-suggestions" || true`
